### PR TITLE
Reverse mortgage funnel: 35% LTV verify gate + dual Meta CAPI events + bug fixes

### DIFF
--- a/.claude/handoffs/reverse-mortgage-lead-analysis.md
+++ b/.claude/handoffs/reverse-mortgage-lead-analysis.md
@@ -1,0 +1,291 @@
+# Handoff: Reverse Mortgage Lead Analysis
+
+**Created**: 2026-05-20
+**For**: Any agent (Claude or analyst) tasked with finding, segmenting, or analyzing reverse-mortgage leads.
+
+---
+
+## Mission
+
+Find and analyze qualified/accepted reverse-mortgage leads in production Supabase. The funnel just rolled out a **35% LTV pre-contact gate** (deployed 2026-05-19); we want to measure quality, acceptance rate, self-correction lift from the verify step, and segment >35% LTV leads for offer-wall / alt-buyer routing.
+
+---
+
+## DB connection
+
+- **Supabase CRM project ID**: `jqjftrlnyysqcwbbigpw`
+- **Table**: `leads`
+- **Tool**: use the supabase MCP `execute_sql` with that `project_id`. If unavailable, use `psql` with credentials from `.env.local` (key `SUPABASE_QUIZ_DB_URL` or equivalent).
+
+---
+
+## What was deployed 2026-05-19 (deploy marker)
+
+1. **Pre-contact verify step** (quiz step 5/6): BatchData lookup + user-confirmable property/mortgage sliders. Lead capture moved from step 4 to step 6.
+2. **Buyer-1 LTV gate**: leads with verified existing-mortgage LTV >35% never deliver to LynqFlux. Lead is still captured + tagged.
+3. **Alt routing**: >35% LTV leads land on `/reverse-mortgage-calculator/results-alt` (placeholder for offer wall / alt buyer).
+4. **Column persistence**: `leads.property_value` and `leads.current_mortgage` now populated on every delivery or DQ tag. **These columns are empty for leads created before 2026-05-19.**
+
+---
+
+## Schema you need
+
+### `leads` columns
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid | Primary key |
+| `session_id` | varchar | Quiz session |
+| `funnel_type` | varchar | Filter on `'reverse-mortgage'` |
+| `created_at` | timestamptz | Lead capture timestamp |
+| `contact` | jsonb | `firstName`, `lastName`, `email`, `phone` |
+| `quiz_answers` | jsonb | See below |
+| `property_value` | numeric | **Populated from 2026-05-19 forward** |
+| `current_mortgage` | numeric | **Populated from 2026-05-19 forward** |
+| `ghl_status` | jsonb | Delivery + DQ tags — see below |
+| `utm_source`, `utm_medium`, `utm_campaign` | text | Attribution |
+| `state`, `zip_code` | text | Geo |
+| `attributed_spend`, `cost_per_lead` | numeric | If populated by BigQuery sync |
+
+### `ghl_status` JSONB paths
+
+| Path | Meaning |
+|---|---|
+| `ghl_status->'lynqflux'->>'success' = 'true'` | **Buyer 1 (LynqFlux) accepted** — this is "qualified/accepted" |
+| `ghl_status->'lynqflux'->>'skipped' = 'true'` | Server-side 35% LTV gate blocked delivery (post-2026-05-19) |
+| `ghl_status->'lynqflux'->>'mocked' = 'true'` | **LOCAL DEV TEST — ALWAYS EXCLUDE** |
+| `ghl_status->'lynqflux'->>'user_verified' = 'true'` | Delivered with user-confirmed (not BatchData) property numbers |
+| `ghl_status->'lynqflux'->>'ltv'` | numeric LTV at delivery (max of client-supplied + server-computed) |
+| `ghl_status->'lynqflux'->'response'->>'message'` | LynqFlux API response text |
+| `ghl_status->'lynqflux'->'response'->'errors'` | Array of rejection reasons (phone dupe, suppression, state, etc.) |
+| `ghl_status->'buyer1_dq'` | Object — leads routed to `/results-alt` because LTV >35% |
+| `ghl_status->'buyer1_dq'->>'reason' = 'ltv_above_35'` | DQ reason (currently only one) |
+| `ghl_status->'buyer1_dq'->>'ltv'` | LTV that triggered the DQ |
+| `ghl_status->'buyer1_dq'->>'batch_data_used'` | true = BatchData LTV; false = user-typed LTV |
+
+### `quiz_answers` JSONB paths (post-2026-05-19 leads)
+
+| Path | Meaning |
+|---|---|
+| `quiz_answers->>'reason'` | Why they want RM (eliminate-mortgage-payments, pay-off-debts, etc.) |
+| `quiz_answers->>'is62Plus'` | Age qualifier (only 62+ pass) |
+| `quiz_answers->>'age'` | **Always '70' — placeholder, never real age collected** |
+| `quiz_answers->'addressInfo'` | street, city, state, zip |
+| `quiz_answers->'verifiedProperty'` | `{ propertyValue, mortgageBalance, ltv, batchDataUsed }` — NEW |
+
+---
+
+## Production filter (always apply)
+
+```sql
+WHERE funnel_type = 'reverse-mortgage'
+  AND COALESCE((ghl_status->'lynqflux'->>'mocked')::boolean, false) = false
+  AND COALESCE(contact->>'email', '') NOT ILIKE 'test+%'
+  -- exclude historical test address (Keenan, appears 15+ times):
+  AND COALESCE(quiz_answers->'addressInfo'->>'street', '') != '1026 40th St'
+```
+
+---
+
+## Canonical lead buckets
+
+### Qualified & accepted (Buyer 1)
+```sql
+WHERE ghl_status->'lynqflux'->>'success' = 'true'
+```
+
+### Delivered but rejected by LynqFlux tech filters (dupe / suppression / state / loan-amount)
+```sql
+WHERE ghl_status->'lynqflux' IS NOT NULL
+  AND COALESCE((ghl_status->'lynqflux'->>'success')::boolean, false) = false
+  AND COALESCE((ghl_status->'lynqflux'->>'skipped')::boolean, false) = false
+```
+
+### Gated out by our 35% LTV server-side check (post-2026-05-19)
+```sql
+WHERE ghl_status->'lynqflux'->>'skipped' = 'true'
+```
+
+### Captured but routed to alt path (LTV >35%, new flow)
+```sql
+WHERE ghl_status->'buyer1_dq' IS NOT NULL
+```
+
+### Captured, no delivery attempt yet (mid-funnel abandonment or pending)
+```sql
+WHERE ghl_status->'lynqflux' IS NULL
+  AND ghl_status->'buyer1_dq' IS NULL
+```
+
+---
+
+## Starter queries
+
+### 1. Acceptance funnel snapshot (last 30d)
+```sql
+SELECT
+  date_trunc('day', created_at) AS day,
+  count(*) AS captured,
+  count(*) FILTER (WHERE ghl_status->'lynqflux'->>'success' = 'true') AS accepted,
+  count(*) FILTER (WHERE ghl_status->'lynqflux' IS NOT NULL
+    AND COALESCE((ghl_status->'lynqflux'->>'success')::boolean, false) = false
+    AND COALESCE((ghl_status->'lynqflux'->>'skipped')::boolean, false) = false) AS lynq_tech_reject,
+  count(*) FILTER (WHERE ghl_status->'lynqflux'->>'skipped' = 'true') AS server_ltv_gate,
+  count(*) FILTER (WHERE ghl_status->'buyer1_dq' IS NOT NULL) AS alt_routed_dq
+FROM leads
+WHERE funnel_type = 'reverse-mortgage'
+  AND COALESCE((ghl_status->'lynqflux'->>'mocked')::boolean, false) = false
+  AND created_at > now() - interval '30 days'
+GROUP BY 1 ORDER BY 1 DESC;
+```
+
+### 2. LTV distribution of accepted leads (post-2026-05-19 only — pre-deploy has no LTV data)
+```sql
+SELECT
+  CASE
+    WHEN (ghl_status->'lynqflux'->>'ltv')::numeric <= 0.20 THEN '≤20%'
+    WHEN (ghl_status->'lynqflux'->>'ltv')::numeric <= 0.30 THEN '20-30%'
+    WHEN (ghl_status->'lynqflux'->>'ltv')::numeric <= 0.35 THEN '30-35%'
+    ELSE '>35% (shouldnt happen post-gate — investigate)'
+  END AS ltv_bucket,
+  count(*) AS accepted,
+  count(*) FILTER (WHERE (ghl_status->'lynqflux'->>'user_verified')::boolean) AS user_verified,
+  count(*) FILTER (WHERE NOT (ghl_status->'lynqflux'->>'user_verified')::boolean) AS batchdata_trusted
+FROM leads
+WHERE funnel_type = 'reverse-mortgage'
+  AND ghl_status->'lynqflux'->>'success' = 'true'
+  AND created_at >= '2026-05-19'
+GROUP BY 1 ORDER BY 1;
+```
+
+### 3. Self-correction lift (post-2026-05-19)
+How many leads that got delivered did so via the user-verified path (i.e., would have been gated as >35% LTV based on BatchData alone but user corrected):
+```sql
+SELECT
+  count(*) AS delivered,
+  count(*) FILTER (WHERE (ghl_status->'lynqflux'->>'user_verified')::boolean) AS user_verified,
+  round(100.0 * count(*) FILTER (WHERE (ghl_status->'lynqflux'->>'user_verified')::boolean) / NULLIF(count(*), 0), 1) AS pct_user_verified
+FROM leads
+WHERE funnel_type = 'reverse-mortgage'
+  AND ghl_status->'lynqflux'->>'success' = 'true'
+  AND created_at >= '2026-05-19';
+```
+
+### 4. Source attribution for accepted leads
+```sql
+SELECT
+  utm_source,
+  utm_campaign,
+  count(*) AS captured,
+  count(*) FILTER (WHERE ghl_status->'lynqflux'->>'success' = 'true') AS accepted,
+  round(100.0 * count(*) FILTER (WHERE ghl_status->'lynqflux'->>'success' = 'true') / NULLIF(count(*), 0), 1) AS acceptance_pct,
+  avg(attributed_spend) FILTER (WHERE ghl_status->'lynqflux'->>'success' = 'true') AS avg_cost_per_accepted
+FROM leads
+WHERE funnel_type = 'reverse-mortgage'
+  AND created_at > now() - interval '30 days'
+  AND COALESCE((ghl_status->'lynqflux'->>'mocked')::boolean, false) = false
+GROUP BY 1,2 ORDER BY accepted DESC LIMIT 20;
+```
+
+### 5. Tech-reject breakdown (LynqFlux rejection reasons)
+```sql
+SELECT
+  ghl_status->'lynqflux'->'response'->'errors'->>0 AS error,
+  count(*)
+FROM leads
+WHERE funnel_type = 'reverse-mortgage'
+  AND ghl_status->'lynqflux' IS NOT NULL
+  AND COALESCE((ghl_status->'lynqflux'->>'success')::boolean, false) = false
+  AND COALESCE((ghl_status->'lynqflux'->>'skipped')::boolean, false) = false
+  AND COALESCE((ghl_status->'lynqflux'->>'mocked')::boolean, false) = false
+GROUP BY 1 ORDER BY 2 DESC;
+```
+
+### 6. Alt-routed DQ cohort (for offer wall / alt buyer sizing)
+```sql
+SELECT
+  count(*) AS dq_leads,
+  avg((ghl_status->'buyer1_dq'->>'ltv')::numeric) AS avg_ltv,
+  avg(property_value) AS avg_property_value,
+  avg(current_mortgage) AS avg_mortgage,
+  count(*) FILTER (WHERE (ghl_status->'buyer1_dq'->>'batch_data_used')::boolean) AS confirmed_via_batchdata,
+  count(*) FILTER (WHERE NOT (ghl_status->'buyer1_dq'->>'batch_data_used')::boolean) AS user_typed_numbers
+FROM leads
+WHERE funnel_type = 'reverse-mortgage'
+  AND ghl_status->'buyer1_dq' IS NOT NULL;
+```
+
+---
+
+## Analyses worth running
+
+1. **Pre-gate vs post-gate acceptance rate** — split at 2026-05-19 boundary. Expected: pre-gate ~72% LynqFlux tech accept, post-gate similar (gate is upstream of tech) but `delivered_count` drops sharply.
+2. **Total delivered volume change** — Expected ~70-80% drop in delivered count after the gate. If smaller, self-correction at the verify step is doing more work than projected.
+3. **User-verified vs BatchData-trusted accepted leads** — quality comparison if buyer DNQ data becomes available.
+4. **LTV distribution of accepted leads** — confirms gate is working (should be 0 leads with LTV>0.35 in the accepted bucket).
+5. **Alt-routed cohort sizing** — basis for offer-wall ROI / alt-buyer pitch.
+6. **Source-level CPL impact** — does the gate hit some Meta campaigns harder than others? Refine targeting if so.
+7. **State distribution** — LynqFlux rejects 3 states; check whether reverse mortgage targeting is hitting those geos.
+
+---
+
+## Critical gotchas
+
+| Gotcha | Mitigation |
+|---|---|
+| Local-dev test leads pollute the data | Filter `ghl_status->'lynqflux'->>'mocked' != 'true'` AND `contact->>'email' NOT ILIKE 'test+%'` |
+| Keenan's San Diego test address (`1026 40th St`) appears 15+ times in historical data | Exclude that specific street |
+| `quiz_answers->>'age'` is always `'70'` (placeholder) | Don't use as a real age signal — the funnel only collects 62+ yes/no |
+| `property_value` / `current_mortgage` columns are empty for pre-2026-05-19 leads | Filter `created_at >= '2026-05-19'` for any column-based analysis |
+| Historical LTV data lives only in Vercel runtime logs (~7 day retention) | If asked about pre-deploy LTV, pull from logs; otherwise use 2026-05-19+ DB data |
+| `funnel_type` value is the string `'reverse-mortgage'` (with hyphen) | Don't use 'reverse_mortgage' or 'reverseMortgage' |
+| LynqFlux "Already delivered" log lines are not failures — they're idempotency skips | Count only first delivery attempts when measuring volume |
+
+---
+
+## LynqFlux wire schema (what we send to Buyer 1)
+
+Endpoint: `POST https://lynqflux.com/data/244/incoming.php` (form-encoded body).
+
+| Field | Format | Example | Notes |
+|---|---|---|---|
+| `propertyvalue` | integer USD | `684899` | No commas, no `$` |
+| `loanamount` | integer USD | `456659` | Min 10000 (LynqFlux validation) |
+| `ltv` | **decimal 0–1, 2 places** | **`0.67`** | NOT percentage. Historical format LynqFlux accepts. Confirm before changing. |
+| `loantype` | enum | `FHA` | One of: Fixed, ARM, Balloon, FHA, VA, Fannie, Freddie, USDA |
+| `creditrating` | enum | `Good` | One of: Excellent, Good, Fair, Poor |
+| `zip` | 5-digit string | `92102` | ZIP+4 is split — only first 5 sent |
+| `state` | 2-letter code | `CA` | |
+| `phone` | 10-digit | `4083927876` | Validated client-side (no 555, no fake sequences) |
+| `email`, `fname`, `lname`, `address`, `city` | strings | — | |
+| `leadid` | Jornaya/LeadID token | — | From `lead.jornaya_lead_id` |
+| `trustedformurl` | URL | — | From `lead.trustedform_cert_url` |
+| `listcode` | always `callready` | — | |
+| `ip` | client IP | — | From request headers or stored |
+| `url` | landing page | — | Query params stripped |
+| `timestamp` | ISO-like `YYYY-MM-DD HH:MM:SS` | — | |
+| `pswd`, `lid` | LynqFlux auth | — | Hardcoded in route |
+
+**On `ltv` specifically**: we send the decimal ratio (e.g. `0.67`), not percentage (e.g. `67`). This is the format LynqFlux has accepted historically. There's some risk LynqFlux is interpreting `0.67` as `0.67%` and silently ignoring the field — they may be recomputing LTV from `propertyvalue` and `loanamount` for their downstream "short-to-close" DQ logic. If you're analyzing the `ltv` field they store on their side, confirm format with them first.
+
+## Reference: deploy-day baselines (for comparison)
+
+From the 6 days of Vercel logs preceding 2026-05-19:
+- 85 unique delivered leads
+- **Median LTV: 66.7% / Mean LTV: 58.0%**
+- **81.2% had BatchData LTV > 35%** (the gate would have caught these)
+- 18.8% had BatchData LTV ≤ 35% (would have sailed through)
+- LynqFlux tech-accept rate: ~72% (51 of 180 lifetime attempts rejected — 21% phone dupes, 4% email suppression, 2% state, 1% loan-amount range)
+
+Use these as the "before" benchmarks for any post-deploy lift analysis.
+
+---
+
+## If you find anything weird
+
+- Leads with `ghl_status->'lynqflux'->>'success' = 'true'` AND LTV >0.35 → **bug**, the server-side gate failed. Report immediately.
+- Leads with `ghl_status->'buyer1_dq'` AND `ghl_status->'lynqflux'->>'success' = 'true'` → **bug**, lead got tagged as DQ but also delivered. Report.
+- Empty `property_value` on post-2026-05-19 delivered leads → deliver-lynqflux endpoint write may have failed. Worth investigating.
+
+---
+
+*Source: this brief was built from the May 2026 reverse-mortgage funnel rebuild. The full context lives in [src/app/api/leads/deliver-lynqflux/route.ts](../../src/app/api/leads/deliver-lynqflux/route.ts), [src/app/api/leads/mark-buyer1-dq/route.ts](../../src/app/api/leads/mark-buyer1-dq/route.ts), [src/components/reverse-mortgage/](../../src/components/reverse-mortgage/), and [src/app/reverse-mortgage-calculator/](../../src/app/reverse-mortgage-calculator/).*

--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Next.js dev (SeniorSimple)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "autoPort": false
+    }
+  ]
+}

--- a/src/app/api/batchdata/lookup/route.ts
+++ b/src/app/api/batchdata/lookup/route.ts
@@ -19,7 +19,16 @@ const log = (message: string, data?: unknown) => {
 interface PropertyLookupData {
   property_value: number
   mortgage_balance: number
-  ltv_ratio: number
+  /**
+   * Loan-to-value ratio as a decimal (0–1).
+   * - null  when LTV is genuinely unknown (no lien data AND BatchData didn't return its own valuation.ltv).
+   *   Downstream code should treat null as "unknown" rather than guess a default.
+   * - 0     when the home is paid off (we have lien data and the balance is 0).
+   * - >0    computed from BatchData's valuation.ltv (preferred) or mortgageBalance / propertyValue (fallback).
+   */
+  ltv_ratio: number | null
+  /** How ltv_ratio was determined — useful for diagnostics. */
+  ltv_source?: 'batchdata_valuation' | 'computed_from_lien' | 'paid_off' | 'unknown'
   address: string
   city: string
   state: string
@@ -259,10 +268,48 @@ export async function POST(request: NextRequest) {
       )
     }
 
+    // Determine ltv_ratio with proper precedence:
+    //   1. BatchData's own valuation.ltv (returned as percentage 0-100; we store as decimal 0-1)
+    //   2. Computed from lien data when present (including 0 = paid off)
+    //   3. null when truly unknown (no lien data and no valuation.ltv from BatchData)
+    // The legacy code defaulted to 0.7 here which mis-classified paid-off homes
+    // as 70% LTV — silently excluding the cleanest leads from downstream gates.
+    const batchDataValuationLtv = toNumber(valuation?.ltv)
+    const hasLienData = !!openLien || (mortgages && mortgages.length > 0)
+    let ltvRatio: number | null = null
+    let ltvSource: PropertyLookupData['ltv_source'] = 'unknown'
+    if (batchDataValuationLtv > 0) {
+      ltvRatio = batchDataValuationLtv / 100
+      ltvSource = 'batchdata_valuation'
+    } else if (hasLienData) {
+      if (mortgageBalance > 0 && propertyValue > 0) {
+        ltvRatio = mortgageBalance / propertyValue
+        ltvSource = 'computed_from_lien'
+      } else {
+        // Lien data exists, no balance → paid off
+        ltvRatio = 0
+        ltvSource = 'paid_off'
+      }
+    } else {
+      // No lien data, no BatchData valuation.ltv → truly unknown
+      ltvRatio = null
+      ltvSource = 'unknown'
+    }
+
+    log('📐 LTV resolution', {
+      batchDataValuationLtv,
+      hasLienData,
+      mortgageBalance,
+      propertyValue,
+      finalLtvRatio: ltvRatio,
+      ltvSource,
+    })
+
     const responseData: PropertyLookupData = {
       property_value: propertyValue,
       mortgage_balance: mortgageBalance || 0,
-      ltv_ratio: mortgageBalance > 0 && propertyValue > 0 ? mortgageBalance / propertyValue : 0.7,
+      ltv_ratio: ltvRatio,
+      ltv_source: ltvSource,
       address: `${property.address?.street}, ${property.address?.city}, ${property.address?.state} ${property.address?.zip}`,
       city: property.address?.city || city,
       state: property.address?.state || state,

--- a/src/app/api/capi/send-lead/route.ts
+++ b/src/app/api/capi/send-lead/route.ts
@@ -4,74 +4,178 @@ import { sendLeadEvent, getMetaPixelIdForFunnel } from '@/lib/meta-capi-service'
 
 /**
  * POST /api/capi/send-lead
- * Diagnostic endpoint: manually send a Lead event to Meta CAPI for an existing lead.
- * Returns the full Meta API response for debugging.
- * Body: { leadId }
+ *
+ * Production CAPI fire path AND diagnostic endpoint. Submit handlers call this
+ * via fetch so that each CAPI fire happens in its own Vercel function invocation
+ * — the per-invocation top-level log line is then a CAPI message, making
+ * `vercel logs -q "Meta CAPI"` find them directly (without having to dig into
+ * the parent request's nested logs[] array).
+ *
+ * Body:
+ *   {
+ *     leadId:       string                              // required — lookup key
+ *     eventId:      string                              // browser+server dedup eventID
+ *     eventName?:   'Lead' | 'QualifiedLead' | string   // default 'Lead'
+ *     value?:       number                              // CAPI value field
+ *     customData?:  Record<string, any>                 // merged into custom_data
+ *     userOverrides?: {                                 // optional override fields from caller
+ *       email?: string
+ *       phone?: string
+ *       firstName?: string
+ *       lastName?: string
+ *       fbp?: string
+ *       fbc?: string
+ *       fbLoginId?: string
+ *       city?: string
+ *       state?: string
+ *       zipCode?: string
+ *       dateOfBirth?: string  // YYYYMMDD
+ *     }
+ *   }
+ *
+ * The route looks up the lead row for IP/UA/contact context, applies any
+ * overrides from the caller, fires the CAPI event, and stamps the lead row with
+ * the result so we never double-fire the same event.
  */
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { leadId } = body;
+    const {
+      leadId,
+      eventId,
+      eventName = 'Lead',
+      value = 0,
+      customData = {},
+      userOverrides = {},
+    } = body || {};
 
     if (!leadId) {
+      console.warn('[Meta CAPI fire] missing leadId');
       return NextResponse.json({ error: 'leadId is required' }, { status: 400 });
     }
 
-    // Look up lead
+    // Look up the lead for context fields. We also use ghl_status to enforce
+    // the once-per-lead-per-event idempotency stamps.
     const { data: lead, error: leadError } = await callreadyQuizDb
       .from('leads')
-      .select('id, contact, quiz_answers, ip_address, trustedform_cert_url, jornaya_lead_id, zip_code, state, landing_page, funnel_type, created_at')
+      .select(
+        'id, contact, quiz_answers, ip_address, trustedform_cert_url, jornaya_lead_id, zip_code, state, landing_page, funnel_type, ghl_status, created_at',
+      )
       .eq('id', leadId)
       .maybeSingle();
 
     if (leadError || !lead) {
-      return NextResponse.json({ error: 'Lead not found', detail: leadError }, { status: 404 });
+      console.warn(`[Meta CAPI fire] lead not found leadId=${leadId}`, leadError);
+      return NextResponse.json({ error: 'Lead not found' }, { status: 404 });
+    }
+
+    const existingGhlStatus = lead.ghl_status || {};
+
+    // Per-event dedup stamps. Both browser+server use the same eventId so Meta
+    // also dedupes at their end; this stamp prevents OUR side from re-firing
+    // (e.g. if submit-without-otp retries the lead row).
+    const stampKey =
+      eventName === 'QualifiedLead' ? 'capi_qualified_lead_sent' : 'capi_lead_sent';
+    const eventIdKey =
+      eventName === 'QualifiedLead' ? 'capi_qualified_lead_event_id' : 'capi_lead_event_id';
+
+    if (existingGhlStatus[stampKey]) {
+      console.log(
+        `[Meta CAPI fire] ⏭️ Skipping ${eventName} for lead=${leadId} — already sent at ${existingGhlStatus[stampKey]}`,
+      );
+      return NextResponse.json({
+        success: true,
+        skipped: true,
+        reason: 'already_sent',
+        leadId,
+        previousEventId: existingGhlStatus[eventIdKey],
+      });
     }
 
     const contact = lead.contact || {};
     const qa = lead.quiz_answers || {};
     const addrInfo = qa.addressInfo || {};
-    const zip5 = (addrInfo.zipCode || qa.zipCode || lead.zip_code || '').replace(/-.*$/, '').substring(0, 5);
-    const city = addrInfo.city || '';
-    const state = addrInfo.state || lead.state || '';
-
+    const zip5 = (userOverrides.zipCode || addrInfo.zipCode || qa.zipCode || lead.zip_code || '')
+      .replace(/-.*$/, '')
+      .substring(0, 5);
+    const city = userOverrides.city || addrInfo.city || qa.city || '';
+    const state = userOverrides.state || addrInfo.state || lead.state || qa.state || '';
     const funnelPixelId = getMetaPixelIdForFunnel(lead.funnel_type);
+
+    console.log(`[Meta CAPI fire] 🚀 Firing ${eventName}`, {
+      leadId,
+      eventId,
+      eventName,
+      funnelType: lead.funnel_type,
+      pixelIdPrefix: funnelPixelId?.substring(0, 6) + '...',
+      hasEmail: !!contact.email,
+      hasPhone: !!contact.phone,
+      hasFbp: !!userOverrides.fbp,
+      hasFbc: !!userOverrides.fbc,
+      value,
+      customDataKeys: Object.keys(customData),
+    });
 
     const result = await sendLeadEvent({
       leadId: lead.id,
-      email: contact.email,
-      phone: contact.phone,
-      firstName: contact.first_name || contact.firstName,
-      lastName: contact.last_name || contact.lastName,
-      ipAddress: lead.ip_address || request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || '',
+      eventId,
+      eventName,
+      email: userOverrides.email || contact.email,
+      phone: userOverrides.phone || contact.phone,
+      firstName: userOverrides.firstName || contact.first_name || contact.firstName,
+      lastName: userOverrides.lastName || contact.last_name || contact.lastName,
+      fbp: userOverrides.fbp,
+      fbc: userOverrides.fbc,
+      fbLoginId: userOverrides.fbLoginId,
+      ipAddress:
+        lead.ip_address || request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() || '',
       userAgent: request.headers.get('user-agent') || '',
       city,
       state,
       zipCode: zip5,
       country: 'US',
+      dateOfBirth: userOverrides.dateOfBirth,
       externalId: lead.id,
-      value: 0,
+      value,
       currency: 'USD',
       customData: {
         quiz_type: lead.funnel_type,
-        content_name: `${lead.funnel_type} Lead`,
         content_category: lead.funnel_type,
+        ...customData,
       },
-      options: {
-        pixelId: funnelPixelId,
-      },
+      options: { pixelId: funnelPixelId },
     });
 
-    console.log(`[Meta CAPI] Manual Lead send for ${leadId}:`, JSON.stringify(result));
+    if (result.success) {
+      console.log(`[Meta CAPI fire] ✅ ${eventName} sent leadId=${leadId} eventId=${result.eventId}`);
+      await callreadyQuizDb
+        .from('leads')
+        .update({
+          ghl_status: {
+            ...existingGhlStatus,
+            [stampKey]: new Date().toISOString(),
+            [eventIdKey]: result.eventId,
+            ...(eventName === 'QualifiedLead' && customData.ltv
+              ? { capi_qualified_lead_ltv: Number(customData.ltv) }
+              : {}),
+          },
+        })
+        .eq('id', lead.id);
+    } else {
+      console.error(`[Meta CAPI fire] ❌ ${eventName} failed leadId=${leadId}`, result.error);
+    }
 
     return NextResponse.json({
-      leadId: lead.id,
-      email: contact.email,
+      success: result.success,
+      leadId,
+      eventName,
+      eventId: result.eventId,
       pixelId: funnelPixelId?.substring(0, 6) + '...',
-      result,
+      response: result.response,
+      error: result.error,
     });
   } catch (error: any) {
-    console.error('[Meta CAPI] Manual send error:', error.message);
+    console.error('[Meta CAPI fire] Error:', error.message);
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 }

--- a/src/app/api/leads/deliver-lynqflux/route.ts
+++ b/src/app/api/leads/deliver-lynqflux/route.ts
@@ -19,6 +19,13 @@ const LYNQFLUX_LID = '244';
 // Buyer requires existing-mortgage LTV ≤ 35% to avoid "short to close" DNQs.
 const MAX_QUALIFYING_LTV = 0.35;
 
+// Feature flag: when off, the LTV gate is bypassed and every lead delivers to
+// LynqFlux regardless of LTV. Default off so we can ship the BatchData fixes
+// (paid-off home recovery, verify-step failsafe) without changing the volume
+// LynqFlux currently receives. Flip to "on" via Vercel env when the per-lead
+// repricing conversation is settled.
+const LTV_GATE_ENABLED = process.env.NEXT_PUBLIC_RM_LTV_GATE === 'on';
+
 export async function OPTIONS() {
   return handleCorsOptions();
 }
@@ -62,7 +69,9 @@ export async function POST(request: NextRequest) {
     }
 
     // Hard gate: LTV must be ≤ 35% to avoid buyer "short to close" DNQs.
-    if (effectiveLtv > MAX_QUALIFYING_LTV) {
+    // Gated behind LTV_GATE_ENABLED env flag — when off (default), every lead
+    // delivers regardless of LTV. Flip NEXT_PUBLIC_RM_LTV_GATE=on to activate.
+    if (LTV_GATE_ENABLED && effectiveLtv > MAX_QUALIFYING_LTV) {
       console.log(
         `🛑 LYNQFLUX SKIPPED — lead=${lead.id} ltv=${(effectiveLtv * 100).toFixed(1)}% exceeds ${MAX_QUALIFYING_LTV * 100}% cap`,
       );

--- a/src/app/api/leads/deliver-lynqflux/route.ts
+++ b/src/app/api/leads/deliver-lynqflux/route.ts
@@ -16,6 +16,9 @@ const LYNQFLUX_URL = 'https://lynqflux.com/data/244/incoming.php';
 const LYNQFLUX_PSWD = 'bXC9qjy4DEnMd4c7';
 const LYNQFLUX_LID = '244';
 
+// Buyer requires existing-mortgage LTV ≤ 35% to avoid "short to close" DNQs.
+const MAX_QUALIFYING_LTV = 0.35;
+
 export async function OPTIONS() {
   return handleCorsOptions();
 }
@@ -23,7 +26,7 @@ export async function OPTIONS() {
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { sessionId, propertyValue, mortgageBalance, ltvRatio, creditRating } = body;
+    const { sessionId, propertyValue, mortgageBalance, ltvRatio, creditRating, userVerified } = body;
 
     if (!sessionId) {
       return createCorsResponse({ error: 'sessionId is required' }, 400);
@@ -31,6 +34,12 @@ export async function POST(request: NextRequest) {
     if (!propertyValue) {
       return createCorsResponse({ error: 'propertyValue is required' }, 400);
     }
+
+    // Compute LTV defensively — client-supplied ratio may be a string or stale.
+    const pvNum = Number(propertyValue) || 0;
+    const mbNum = Number(mortgageBalance) || 0;
+    const ratioFromValues = pvNum > 0 ? mbNum / pvNum : 0;
+    const effectiveLtv = Math.max(Number(ltvRatio) || 0, ratioFromValues);
 
     // Look up the lead by session_id
     const { data: lead, error: leadError } = await callreadyQuizDb
@@ -50,6 +59,38 @@ export async function POST(request: NextRequest) {
     if (lead.ghl_status?.lynqflux?.success) {
       console.log(`[LynqFlux] Already delivered for lead=${lead.id}, skipping`);
       return createCorsResponse({ success: true, message: 'Already delivered', leadId: lead.id });
+    }
+
+    // Hard gate: LTV must be ≤ 35% to avoid buyer "short to close" DNQs.
+    if (effectiveLtv > MAX_QUALIFYING_LTV) {
+      console.log(
+        `🛑 LYNQFLUX SKIPPED — lead=${lead.id} ltv=${(effectiveLtv * 100).toFixed(1)}% exceeds ${MAX_QUALIFYING_LTV * 100}% cap`,
+      );
+      const existingGhlStatus = lead.ghl_status || {};
+      await callreadyQuizDb
+        .from('leads')
+        .update({
+          property_value: pvNum || null,
+          current_mortgage: mbNum || null,
+          ghl_status: {
+            ...existingGhlStatus,
+            lynqflux: {
+              skipped: true,
+              reason: 'ltv_above_35',
+              ltv: Number(effectiveLtv.toFixed(4)),
+              user_verified: !!userVerified,
+              timestamp: new Date().toISOString(),
+            },
+          },
+        })
+        .eq('id', lead.id);
+      return createCorsResponse({
+        success: false,
+        skipped: true,
+        reason: 'ltv_above_35',
+        ltv: Number(effectiveLtv.toFixed(4)),
+        leadId: lead.id,
+      });
     }
 
     // Contact data is JSONB
@@ -102,17 +143,18 @@ export async function POST(request: NextRequest) {
     // loantype: Fixed, ARM, Balloon, FHA, VA, Fannie, Freddie, USDA
     lynqParams.set('loantype', 'FHA');
 
-    // Property data from BatchData
-    lynqParams.set('propertyvalue', String(Math.round(Number(propertyValue))));
-    lynqParams.set('ltv', String(Number(ltvRatio || 0).toFixed(2)));
+    // Property data (BatchData or user-verified)
+    lynqParams.set('propertyvalue', String(Math.round(pvNum)));
+    lynqParams.set('ltv', effectiveLtv.toFixed(2));
 
     console.log('[LynqFlux] 📤 Sending reverse mortgage lead (deferred):', {
       leadId: lead.id,
       email: contact.email,
       zip: zip5,
-      propertyValue,
+      propertyValue: pvNum,
       mortgageBalance: loanAmt,
-      ltv: ltvRatio,
+      ltv: effectiveLtv.toFixed(4),
+      userVerified: !!userVerified,
       creditRating: mappedCredit,
     });
 
@@ -138,11 +180,13 @@ export async function POST(request: NextRequest) {
       leadId: lead.id,
     });
 
-    // Persist result in ghl_status.lynqflux
+    // Persist result in ghl_status.lynqflux + property/mortgage on the lead row
     const existingGhlStatus = lead.ghl_status || {};
     await callreadyQuizDb
       .from('leads')
       .update({
+        property_value: pvNum || null,
+        current_mortgage: mbNum || null,
         ghl_status: {
           ...existingGhlStatus,
           lynqflux: {
@@ -150,6 +194,8 @@ export async function POST(request: NextRequest) {
             response: lynqJson,
             timestamp: new Date().toISOString(),
             success: lynqResponse.ok && lynqJson.status === 'success',
+            ltv: Number(effectiveLtv.toFixed(4)),
+            user_verified: !!userVerified,
           },
         },
       })

--- a/src/app/api/leads/deliver-lynqflux/route.ts
+++ b/src/app/api/leads/deliver-lynqflux/route.ts
@@ -144,6 +144,18 @@ export async function POST(request: NextRequest) {
     lynqParams.set('loantype', 'FHA');
 
     // Property data (BatchData or user-verified)
+    // ─── LynqFlux schema mapping ──────────────────────────────────────────────
+    // propertyvalue: integer USD (no commas, no currency symbol). e.g. "684899"
+    // loanamount:    integer USD (set above; min 10000 per LynqFlux validation)
+    // ltv:           DECIMAL ratio 0–1, two decimals. e.g. "0.67" (NOT "67")
+    //                This is the format LynqFlux has accepted historically; do not
+    //                change to percentage without confirming with them first
+    //                (their `incoming.php` endpoint is undocumented in our repo;
+    //                acceptance ≠ correct interpretation but they may also compute
+    //                LTV themselves from propertyvalue + loanamount downstream).
+    // loantype:      enum "Fixed|ARM|Balloon|FHA|VA|Fannie|Freddie|USDA"
+    // creditrating:  enum "Excellent|Good|Fair|Poor" (set above)
+    // ──────────────────────────────────────────────────────────────────────────
     lynqParams.set('propertyvalue', String(Math.round(pvNum)));
     lynqParams.set('ltv', effectiveLtv.toFixed(2));
 
@@ -157,6 +169,37 @@ export async function POST(request: NextRequest) {
       userVerified: !!userVerified,
       creditRating: mappedCredit,
     });
+
+    // Local dev escape hatch: skip the actual POST when DISABLE_LYNQFLUX is set.
+    if (process.env.DISABLE_LYNQFLUX === 'true') {
+      console.log('🧪 [LynqFlux] DISABLE_LYNQFLUX=true — skipping real POST, returning mock success');
+      const existingGhlStatus = lead.ghl_status || {};
+      await callreadyQuizDb
+        .from('leads')
+        .update({
+          property_value: pvNum || null,
+          current_mortgage: mbNum || null,
+          ghl_status: {
+            ...existingGhlStatus,
+            lynqflux: {
+              status: 200,
+              response: { status: 'mocked', message: 'DISABLE_LYNQFLUX=true' },
+              timestamp: new Date().toISOString(),
+              success: true,
+              mocked: true,
+              ltv: Number(effectiveLtv.toFixed(4)),
+              user_verified: !!userVerified,
+            },
+          },
+        })
+        .eq('id', lead.id);
+      return createCorsResponse({
+        success: true,
+        mocked: true,
+        leadId: lead.id,
+        wouldHaveSent: Object.fromEntries(lynqParams.entries()),
+      });
+    }
 
     // POST to LynqFlux
     const lynqController = new AbortController();

--- a/src/app/api/leads/mark-buyer1-dq/route.ts
+++ b/src/app/api/leads/mark-buyer1-dq/route.ts
@@ -1,0 +1,89 @@
+import { NextRequest } from 'next/server';
+import { callreadyQuizDb } from '@/lib/callready-quiz-db';
+import { createCorsResponse, handleCorsOptions } from '@/lib/cors-headers';
+
+/**
+ * POST /api/leads/mark-buyer1-dq
+ *
+ * Tags a reverse-mortgage lead as not-a-fit for Buyer 1 (LynqFlux) because their
+ * existing-mortgage LTV exceeded the 35% threshold. We still captured the lead —
+ * this endpoint just records the DQ reason and the verified property numbers so
+ * we can:
+ *   - Filter these out of Buyer 1 delivery (deliver-lynqflux is never called)
+ *   - Segment them in SQL for downstream routing (offer wall, alt buyer)
+ *   - Measure conversion of the alt path over time
+ *
+ * Body: { sessionId, propertyValue, mortgageBalance, ltv, batchDataUsed }
+ */
+
+export async function OPTIONS() {
+  return handleCorsOptions();
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { sessionId, propertyValue, mortgageBalance, ltv, batchDataUsed } = body;
+
+    if (!sessionId) {
+      return createCorsResponse({ error: 'sessionId is required' }, 400);
+    }
+
+    const pvNum = Number(propertyValue) || 0;
+    const mbNum = Number(mortgageBalance) || 0;
+    const ltvNum = Number(ltv) || (pvNum > 0 ? mbNum / pvNum : 0);
+
+    // Look up the lead by session_id (most recent)
+    const { data: lead, error: leadError } = await callreadyQuizDb
+      .from('leads')
+      .select('id, ghl_status')
+      .eq('session_id', sessionId)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (leadError || !lead) {
+      console.error('[buyer1-dq] Lead not found for session:', sessionId, leadError);
+      return createCorsResponse({ error: 'Lead not found' }, 404);
+    }
+
+    // Idempotency: if already tagged, return success
+    if (lead.ghl_status?.buyer1_dq) {
+      console.log(`[buyer1-dq] Already tagged lead=${lead.id}`);
+      return createCorsResponse({ success: true, leadId: lead.id, alreadyTagged: true });
+    }
+
+    const existingGhlStatus = lead.ghl_status || {};
+    const { error: updateError } = await callreadyQuizDb
+      .from('leads')
+      .update({
+        property_value: pvNum || null,
+        current_mortgage: mbNum || null,
+        ghl_status: {
+          ...existingGhlStatus,
+          buyer1_dq: {
+            reason: 'ltv_above_35',
+            ltv: Number(ltvNum.toFixed(4)),
+            property_value: pvNum,
+            mortgage_balance: mbNum,
+            batch_data_used: !!batchDataUsed,
+            timestamp: new Date().toISOString(),
+          },
+        },
+      })
+      .eq('id', lead.id);
+
+    if (updateError) {
+      console.error('[buyer1-dq] Failed to tag lead:', lead.id, updateError);
+      return createCorsResponse({ error: 'Failed to tag lead' }, 500);
+    }
+
+    console.log(
+      `🟠 BUYER1 DQ — lead=${lead.id} ltv=${(ltvNum * 100).toFixed(1)}% (alt-routing candidate)`,
+    );
+    return createCorsResponse({ success: true, leadId: lead.id });
+  } catch (error: any) {
+    console.error('[buyer1-dq] Error:', error.message);
+    return createCorsResponse({ success: false, error: error.message }, 500);
+  }
+}

--- a/src/app/api/leads/submit-without-otp/route.ts
+++ b/src/app/api/leads/submit-without-otp/route.ts
@@ -766,17 +766,38 @@ export async function POST(request: NextRequest) {
     // DEDUP: Only send CAPI Lead once per lead — skip if already sent
     const existingGhlStatus = lead.ghl_status || {};
     const capiAlreadySent = existingGhlStatus?.capi_lead_sent;
+    // Verbose entry logging: production currently shows 0 Lead CAPI fires for
+    // dozens of submits with no skip/sent/error logs. These breadcrumbs help
+    // identify where the silent skip is happening.
+    console.log('[Meta CAPI] 🔵 Lead block ENTRY', {
+      leadId: lead.id,
+      funnelType,
+      capiAlreadySent: !!capiAlreadySent,
+      capiEventIdReceived: !!body.capiEventId,
+      hasMetaCookies: !!body.metaCookies,
+      ghlStatusKeys: Object.keys(existingGhlStatus),
+    });
     if (capiAlreadySent) {
       console.log(`[Meta CAPI] ⏭️ Skipping Lead event — already sent at ${capiAlreadySent} for lead=${lead.id}`);
     }
 
     // Lead event fires for EVERY submitted lead (current campaign keeps full
     // optimization volume). The QualifiedLead custom event is a separate fire
-    // gated on LTV >= 0.50 — see below, after the Lead event block.
+    // gated on LTV ≤ 0.50 — see below, after the Lead event block.
 
     if (!capiAlreadySent) try {
+      console.log('[Meta CAPI] 🔵 Lead block — entering sendLeadEvent prep', { leadId: lead.id });
       // Get funnel-specific pixel ID
       const funnelPixelId = getMetaPixelIdForFunnel(funnelType);
+      // Diagnostic: confirm pixel ID + access token presence per funnel before fire.
+      // Lets us see in logs whether a missing env var is silently failing the send.
+      console.log('[Meta CAPI] 🔵 Lead block — pixel/token config', {
+        leadId: lead.id,
+        funnelType,
+        funnelPixelId,
+        hasAccessTokenSeniorSimple: !!process.env.META_CAPI_ACCESS_TOKEN_SENIORSIMPLE,
+        hasAccessTokenDefault: !!process.env.META_CAPI_ACCESS_TOKEN,
+      });
 
       // Convert dob YYYY-MM-DD → YYYYMMDD for Meta
       const dobForCapi = dobFormatted ? dobFormatted.replace(/-/g, '') : null;

--- a/src/app/api/leads/submit-without-otp/route.ts
+++ b/src/app/api/leads/submit-without-otp/route.ts
@@ -786,91 +786,123 @@ export async function POST(request: NextRequest) {
     // gated on LTV ≤ 0.50 — see below, after the Lead event block.
 
     if (!capiAlreadySent) try {
-      console.log('[Meta CAPI] 🔵 Lead block — entering sendLeadEvent prep', { leadId: lead.id });
-      // Get funnel-specific pixel ID
-      const funnelPixelId = getMetaPixelIdForFunnel(funnelType);
-      // Diagnostic: confirm pixel ID + access token presence per funnel before fire.
-      // Lets us see in logs whether a missing env var is silently failing the send.
-      console.log('[Meta CAPI] 🔵 Lead block — pixel/token config', {
-        leadId: lead.id,
-        funnelType,
-        funnelPixelId,
-        hasAccessTokenSeniorSimple: !!process.env.META_CAPI_ACCESS_TOKEN_SENIORSIMPLE,
-        hasAccessTokenDefault: !!process.env.META_CAPI_ACCESS_TOKEN,
-      });
-
-      // Convert dob YYYY-MM-DD → YYYYMMDD for Meta
+      // ──────────────────────────────────────────────────────────────────────
+      // For reverse-mortgage, fire CAPI via a dedicated route (/api/capi/send-lead)
+      // so the CAPI logs land in their own Vercel invocation. That makes
+      // `vercel logs -q "Meta CAPI"` find Lead fires at the top level instead
+      // of nested in this request's logs[] array.
+      // Other funnels (annuity, RMD, etc.) keep the inline path to avoid scope.
+      // ──────────────────────────────────────────────────────────────────────
       const dobForCapi = dobFormatted ? dobFormatted.replace(/-/g, '') : null;
-      // For reverse mortgage, use propertyValue as the lead value signal
       const capiValue = isReverseMortgage
         ? (quizAnswers?.propertyData?.property_value || quizAnswers?.propertyValue || coverageAmount || 0)
         : (coverageAmount || 0);
 
-      const capiResult = await sendLeadEvent({
-        leadId: lead.id,
-        eventId: body.capiEventId, // Client-generated eventID for browser+server dedup
-        email: email,
-        phone: phoneNumber,
-        firstName: firstName,
-        lastName: lastName,
-        fbp: body.metaCookies?.fbp,
-        fbc: body.metaCookies?.fbc,
-        fbLoginId: body.metaCookies?.fbLoginId,
-        ipAddress: ipAddress,
-        userAgent: userAgent,
-        // Geo/demo for EMQ 8+
-        city: city || quizAnswers?.city || '',
-        state: state || addressState || '',
-        zipCode: zipCode || addressZip || '',
-        country: 'US',
-        dateOfBirth: dobForCapi,
-        externalId: lead.id,
-        value: capiValue,
-        currency: 'USD',
-        customData: {
-          quiz_type: funnelType,
-          content_name: isReverseMortgage ? 'Reverse Mortgage Lead' : `${funnelType} Lead`,
-          content_category: funnelType,
-          coverage_amount: coverageAmount,
-          retirement_savings: retirementSavings,
-          allocation_percent: allocationPercent,
-          property_value: quizAnswers?.verifiedProperty?.propertyValue
-            || quizAnswers?.propertyData?.property_value
-            || undefined,
-          equity_available: quizAnswers?.propertyData?.equity_available || undefined,
-          // LTV signal for Meta optimization (only sent when the LTV gate passed,
-          // i.e. >= 0.50). Helps Meta build a value-based optimization model.
-          ltv: isReverseMortgage
-            ? Math.max(
-                Number(quizAnswers?.verifiedProperty?.ltv) || 0,
-                Number(quizAnswers?.verifiedProperty?.batchDataLtv) || 0,
-              ) || undefined
-            : undefined,
-          ltv_source: isReverseMortgage
-            ? (quizAnswers?.verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified')
-            : undefined,
-        },
-        options: {
-          pixelId: funnelPixelId,
-        },
-      });
-      
-      if (!capiResult.success) {
-        console.error('[Meta CAPI] Lead event failed:', capiResult.error);
-        // Don't fail the request - just log
+      const sharedCustomData = {
+        content_name: isReverseMortgage ? 'Reverse Mortgage Lead' : `${funnelType} Lead`,
+        coverage_amount: coverageAmount,
+        retirement_savings: retirementSavings,
+        allocation_percent: allocationPercent,
+        property_value: quizAnswers?.verifiedProperty?.propertyValue
+          || quizAnswers?.propertyData?.property_value
+          || undefined,
+        equity_available: quizAnswers?.propertyData?.equity_available || undefined,
+        ltv: isReverseMortgage
+          ? Math.max(
+              Number(quizAnswers?.verifiedProperty?.ltv) || 0,
+              Number(quizAnswers?.verifiedProperty?.batchDataLtv) || 0,
+            ) || undefined
+          : undefined,
+        ltv_source: isReverseMortgage
+          ? (quizAnswers?.verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified')
+          : undefined,
+      };
+
+      if (isReverseMortgage) {
+        // Fire-and-await a separate Vercel invocation. The CAPI logs become
+        // top-level in that invocation, surfacing to vercel logs -q searches.
+        const origin = new URL(request.url).origin;
+        console.log('[Meta CAPI] 🔵 Dispatching Lead fire to /api/capi/send-lead', {
+          leadId: lead.id,
+          eventId: body.capiEventId,
+          origin,
+        });
+        try {
+          const fireResp = await fetch(`${origin}/api/capi/send-lead`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              leadId: lead.id,
+              eventId: body.capiEventId,
+              eventName: 'Lead',
+              value: capiValue,
+              customData: sharedCustomData,
+              userOverrides: {
+                email,
+                phone: phoneNumber,
+                firstName,
+                lastName,
+                fbp: body.metaCookies?.fbp,
+                fbc: body.metaCookies?.fbc,
+                fbLoginId: body.metaCookies?.fbLoginId,
+                city: city || quizAnswers?.city || '',
+                state: state || addressState || '',
+                zipCode: zipCode || addressZip || '',
+                dateOfBirth: dobForCapi,
+              },
+            }),
+          });
+          const fireJson = await fireResp.json().catch(() => ({}));
+          console.log('[Meta CAPI] 🔵 Lead fire dispatch result', {
+            leadId: lead.id,
+            status: fireResp.status,
+            success: fireJson?.success,
+            skipped: fireJson?.skipped,
+          });
+        } catch (dispatchErr) {
+          console.error('[Meta CAPI] Lead dispatch error:', dispatchErr);
+        }
       } else {
-        console.log('[Meta CAPI] Lead event sent:', capiResult.eventId);
-        // Stamp capi_lead_sent so we never double-send for this lead
-        await callreadyQuizDb
-          .from('leads')
-          .update({
-            ghl_status: {
-              ...existingGhlStatus,
-              capi_lead_sent: new Date().toISOString(),
-              capi_lead_event_id: capiResult.eventId,
-            },
-          })
-          .eq('id', lead.id);
+        // Non-reverse-mortgage funnels: keep the inline path (unchanged behavior).
+        const funnelPixelId = getMetaPixelIdForFunnel(funnelType);
+        const capiResult = await sendLeadEvent({
+          leadId: lead.id,
+          eventId: body.capiEventId,
+          email,
+          phone: phoneNumber,
+          firstName,
+          lastName,
+          fbp: body.metaCookies?.fbp,
+          fbc: body.metaCookies?.fbc,
+          fbLoginId: body.metaCookies?.fbLoginId,
+          ipAddress,
+          userAgent,
+          city: city || quizAnswers?.city || '',
+          state: state || addressState || '',
+          zipCode: zipCode || addressZip || '',
+          country: 'US',
+          dateOfBirth: dobForCapi,
+          externalId: lead.id,
+          value: capiValue,
+          currency: 'USD',
+          customData: { quiz_type: funnelType, content_category: funnelType, ...sharedCustomData },
+          options: { pixelId: funnelPixelId },
+        });
+        if (!capiResult.success) {
+          console.error('[Meta CAPI] Lead event failed:', capiResult.error);
+        } else {
+          console.log('[Meta CAPI] Lead event sent:', capiResult.eventId);
+          await callreadyQuizDb
+            .from('leads')
+            .update({
+              ghl_status: {
+                ...existingGhlStatus,
+                capi_lead_sent: new Date().toISOString(),
+                capi_lead_event_id: capiResult.eventId,
+              },
+            })
+            .eq('id', lead.id);
+        }
       }
     } catch (capiError) {
       console.error('[Meta CAPI] Error:', capiError);
@@ -902,58 +934,56 @@ export async function POST(request: NextRequest) {
         alreadySent: !!alreadySent,
       });
 
-      if (serverShouldFire && !alreadySent) try {
-        const funnelPixelId = getMetaPixelIdForFunnel(funnelType);
-        const qResult = await sendLeadEvent({
+      if (serverShouldFire && !alreadySent) {
+        // Dispatch QualifiedLead to /api/capi/send-lead so the CAPI logs land
+        // in a dedicated Vercel invocation (top-level visible to vercel logs -q).
+        const origin = new URL(request.url).origin;
+        console.log('[Meta CAPI] 🔵 Dispatching QualifiedLead fire to /api/capi/send-lead', {
           leadId: lead.id,
-          eventId: body.qualifiedLeadEventId, // shared with browser pixel for dedup
-          eventName: 'QualifiedLead', // custom event
-          email,
-          phone: phoneNumber,
-          firstName,
-          lastName,
-          fbp: body.metaCookies?.fbp,
-          fbc: body.metaCookies?.fbc,
-          fbLoginId: body.metaCookies?.fbLoginId,
-          ipAddress,
-          userAgent,
-          city: city || quizAnswers?.city || '',
-          state: state || addressState || '',
-          zipCode: zipCode || addressZip || '',
-          country: 'US',
-          externalId: lead.id,
-          value: 0,
-          currency: 'USD',
-          customData: {
-            quiz_type: funnelType,
-            content_name: 'Reverse Mortgage Qualified Lead (LTV≤50% / equity≥50%)',
-            content_category: funnelType,
-            property_value: vp.propertyValue || undefined,
-            mortgage_balance: vp.mortgageBalance || undefined,
-            ltv: gatingLtv,
-            ltv_source: vp.batchDataUsed ? 'batchdata' : 'user_verified',
-            ltv_ceiling: QUALIFIED_CEILING,
-          },
-          options: { pixelId: funnelPixelId },
+          eventId: body.qualifiedLeadEventId,
+          gatingLtv,
         });
-        if (qResult.success) {
-          console.log('[Meta CAPI] QualifiedLead event sent:', qResult.eventId);
-          await callreadyQuizDb
-            .from('leads')
-            .update({
-              ghl_status: {
-                ...existingGhlStatus,
-                capi_qualified_lead_sent: new Date().toISOString(),
-                capi_qualified_lead_event_id: qResult.eventId,
-                capi_qualified_lead_ltv: gatingLtv,
+        try {
+          const qResp = await fetch(`${origin}/api/capi/send-lead`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              leadId: lead.id,
+              eventId: body.qualifiedLeadEventId,
+              eventName: 'QualifiedLead',
+              value: 0,
+              customData: {
+                content_name: 'Reverse Mortgage Qualified Lead (LTV≤50% / equity≥50%)',
+                property_value: vp.propertyValue || undefined,
+                mortgage_balance: vp.mortgageBalance || undefined,
+                ltv: gatingLtv,
+                ltv_source: vp.batchDataUsed ? 'batchdata' : 'user_verified',
+                ltv_ceiling: QUALIFIED_CEILING,
               },
-            })
-            .eq('id', lead.id);
-        } else {
-          console.error('[Meta CAPI] QualifiedLead event failed:', qResult.error);
+              userOverrides: {
+                email,
+                phone: phoneNumber,
+                firstName,
+                lastName,
+                fbp: body.metaCookies?.fbp,
+                fbc: body.metaCookies?.fbc,
+                fbLoginId: body.metaCookies?.fbLoginId,
+                city: city || quizAnswers?.city || '',
+                state: state || addressState || '',
+                zipCode: zipCode || addressZip || '',
+              },
+            }),
+          });
+          const qJson = await qResp.json().catch(() => ({}));
+          console.log('[Meta CAPI] 🔵 QualifiedLead fire dispatch result', {
+            leadId: lead.id,
+            status: qResp.status,
+            success: qJson?.success,
+            skipped: qJson?.skipped,
+          });
+        } catch (qDispatchErr) {
+          console.error('[Meta CAPI] QualifiedLead dispatch error:', qDispatchErr);
         }
-      } catch (qErr) {
-        console.error('[Meta CAPI] QualifiedLead error:', qErr);
       }
     }
 

--- a/src/app/api/leads/submit-without-otp/route.ts
+++ b/src/app/api/leads/submit-without-otp/route.ts
@@ -770,6 +770,10 @@ export async function POST(request: NextRequest) {
       console.log(`[Meta CAPI] ⏭️ Skipping Lead event — already sent at ${capiAlreadySent} for lead=${lead.id}`);
     }
 
+    // Lead event fires for EVERY submitted lead (current campaign keeps full
+    // optimization volume). The QualifiedLead custom event is a separate fire
+    // gated on LTV >= 0.50 — see below, after the Lead event block.
+
     if (!capiAlreadySent) try {
       // Get funnel-specific pixel ID
       const funnelPixelId = getMetaPixelIdForFunnel(funnelType);
@@ -809,8 +813,21 @@ export async function POST(request: NextRequest) {
           coverage_amount: coverageAmount,
           retirement_savings: retirementSavings,
           allocation_percent: allocationPercent,
-          property_value: quizAnswers?.propertyData?.property_value || undefined,
+          property_value: quizAnswers?.verifiedProperty?.propertyValue
+            || quizAnswers?.propertyData?.property_value
+            || undefined,
           equity_available: quizAnswers?.propertyData?.equity_available || undefined,
+          // LTV signal for Meta optimization (only sent when the LTV gate passed,
+          // i.e. >= 0.50). Helps Meta build a value-based optimization model.
+          ltv: isReverseMortgage
+            ? Math.max(
+                Number(quizAnswers?.verifiedProperty?.ltv) || 0,
+                Number(quizAnswers?.verifiedProperty?.batchDataLtv) || 0,
+              ) || undefined
+            : undefined,
+          ltv_source: isReverseMortgage
+            ? (quizAnswers?.verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified')
+            : undefined,
         },
         options: {
           pixelId: funnelPixelId,
@@ -837,6 +854,85 @@ export async function POST(request: NextRequest) {
     } catch (capiError) {
       console.error('[Meta CAPI] Error:', capiError);
       // Don't fail the request - CAPI is non-critical
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // QualifiedLead custom event (separate from Lead) — fires only for ≥50% LTV.
+    // Builds the optimization signal for a duplicated Meta campaign that will
+    // optimize on higher-intent leads once it has stable volume (~50 events/wk).
+    // ────────────────────────────────────────────────────────────────────────
+    if (isReverseMortgage && body.qualifiedLeadEventId) {
+      const vp = quizAnswers?.verifiedProperty || {};
+      const gatingLtv = Math.max(Number(vp.ltv) || 0, Number(vp.batchDataLtv) || 0);
+      const QUALIFIED_FLOOR = 0.50;
+
+      // Defensive: re-check the gate server-side. Browser only sets eventId when
+      // gate passes, but server validates the actual stored LTV.
+      const serverShouldFire = gatingLtv >= QUALIFIED_FLOOR;
+      const alreadySent = existingGhlStatus?.capi_qualified_lead_sent;
+
+      console.log('[Meta CAPI] QualifiedLead gate (server)', {
+        leadId: lead.id,
+        gatingLtv,
+        floor: QUALIFIED_FLOOR,
+        clientSentEventId: !!body.qualifiedLeadEventId,
+        serverShouldFire,
+        alreadySent: !!alreadySent,
+      });
+
+      if (serverShouldFire && !alreadySent) try {
+        const funnelPixelId = getMetaPixelIdForFunnel(funnelType);
+        const qResult = await sendLeadEvent({
+          leadId: lead.id,
+          eventId: body.qualifiedLeadEventId, // shared with browser pixel for dedup
+          eventName: 'QualifiedLead', // custom event
+          email,
+          phone: phoneNumber,
+          firstName,
+          lastName,
+          fbp: body.metaCookies?.fbp,
+          fbc: body.metaCookies?.fbc,
+          fbLoginId: body.metaCookies?.fbLoginId,
+          ipAddress,
+          userAgent,
+          city: city || quizAnswers?.city || '',
+          state: state || addressState || '',
+          zipCode: zipCode || addressZip || '',
+          country: 'US',
+          externalId: lead.id,
+          value: 0,
+          currency: 'USD',
+          customData: {
+            quiz_type: funnelType,
+            content_name: 'Reverse Mortgage Qualified Lead (LTV≥50%)',
+            content_category: funnelType,
+            property_value: vp.propertyValue || undefined,
+            mortgage_balance: vp.mortgageBalance || undefined,
+            ltv: gatingLtv,
+            ltv_source: vp.batchDataUsed ? 'batchdata' : 'user_verified',
+            ltv_floor: QUALIFIED_FLOOR,
+          },
+          options: { pixelId: funnelPixelId },
+        });
+        if (qResult.success) {
+          console.log('[Meta CAPI] QualifiedLead event sent:', qResult.eventId);
+          await callreadyQuizDb
+            .from('leads')
+            .update({
+              ghl_status: {
+                ...existingGhlStatus,
+                capi_qualified_lead_sent: new Date().toISOString(),
+                capi_qualified_lead_event_id: qResult.eventId,
+                capi_qualified_lead_ltv: gatingLtv,
+              },
+            })
+            .eq('id', lead.id);
+        } else {
+          console.error('[Meta CAPI] QualifiedLead event failed:', qResult.error);
+        }
+      } catch (qErr) {
+        console.error('[Meta CAPI] QualifiedLead error:', qErr);
+      }
     }
 
     // Send to GHL webhook with timeout

--- a/src/app/api/leads/submit-without-otp/route.ts
+++ b/src/app/api/leads/submit-without-otp/route.ts
@@ -857,24 +857,25 @@ export async function POST(request: NextRequest) {
     }
 
     // ────────────────────────────────────────────────────────────────────────
-    // QualifiedLead custom event (separate from Lead) — fires only for ≥50% LTV.
-    // Builds the optimization signal for a duplicated Meta campaign that will
-    // optimize on higher-intent leads once it has stable volume (~50 events/wk).
+    // QualifiedLead custom event (separate from Lead) — fires only when LTV ≤ 50%
+    // (≥50% equity — the leads buyer-1 actually wants). Builds the optimization
+    // signal for a duplicated Meta campaign that will optimize on higher-intent
+    // leads once it has stable volume (~50 events/week).
     // ────────────────────────────────────────────────────────────────────────
     if (isReverseMortgage && body.qualifiedLeadEventId) {
       const vp = quizAnswers?.verifiedProperty || {};
       const gatingLtv = Math.max(Number(vp.ltv) || 0, Number(vp.batchDataLtv) || 0);
-      const QUALIFIED_FLOOR = 0.50;
+      const QUALIFIED_CEILING = 0.50;
 
       // Defensive: re-check the gate server-side. Browser only sets eventId when
       // gate passes, but server validates the actual stored LTV.
-      const serverShouldFire = gatingLtv >= QUALIFIED_FLOOR;
+      const serverShouldFire = gatingLtv > 0 && gatingLtv <= QUALIFIED_CEILING;
       const alreadySent = existingGhlStatus?.capi_qualified_lead_sent;
 
       console.log('[Meta CAPI] QualifiedLead gate (server)', {
         leadId: lead.id,
         gatingLtv,
-        floor: QUALIFIED_FLOOR,
+        ceiling: QUALIFIED_CEILING,
         clientSentEventId: !!body.qualifiedLeadEventId,
         serverShouldFire,
         alreadySent: !!alreadySent,
@@ -904,13 +905,13 @@ export async function POST(request: NextRequest) {
           currency: 'USD',
           customData: {
             quiz_type: funnelType,
-            content_name: 'Reverse Mortgage Qualified Lead (LTV≥50%)',
+            content_name: 'Reverse Mortgage Qualified Lead (LTV≤50% / equity≥50%)',
             content_category: funnelType,
             property_value: vp.propertyValue || undefined,
             mortgage_balance: vp.mortgageBalance || undefined,
             ltv: gatingLtv,
             ltv_source: vp.batchDataUsed ? 'batchdata' : 'user_verified',
-            ltv_floor: QUALIFIED_FLOOR,
+            ltv_ceiling: QUALIFIED_CEILING,
           },
           options: { pixelId: funnelPixelId },
         });

--- a/src/app/api/poll/route.ts
+++ b/src/app/api/poll/route.ts
@@ -2,10 +2,23 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { createHash } from 'crypto'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
+// Lazy-init: calling createClient at module load with undefined env vars throws
+// "supabaseKey is required" during `next build` page-data collection, which
+// crashes every preview deploy where the env var isn't set. Defer construction
+// to first handler invocation — same runtime semantics, build no longer crashes.
+// Cache typed `any` because createClient's generic return type otherwise collapses
+// to a `never` database type and breaks downstream .from(...).single() calls.
+let _supabase: any = null
+function getSupabase() {
+  if (_supabase) return _supabase
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    throw new Error('Supabase not configured: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing')
+  }
+  _supabase = createClient(url, key)
+  return _supabase
+}
 
 const SITE_ID = process.env.NEXT_PUBLIC_SITE_ID || 'seniorsimple'
 const IP_HASH_SALT = process.env.POLL_IP_HASH_SALT || 'default-poll-salt-change-me'
@@ -35,6 +48,8 @@ export async function GET(request: NextRequest) {
       { status: 400 }
     )
   }
+
+  const supabase = getSupabase()
 
   // Resolve issue_id from slug
   const { data: issue, error: issueError } = await supabase

--- a/src/app/api/subscribe/route.ts
+++ b/src/app/api/subscribe/route.ts
@@ -1,10 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
+// Lazy-init: see /api/poll/route.ts for full rationale. Module-load createClient
+// throws "supabaseKey is required" during `next build` when env var is missing.
+// Typed `any` to avoid createClient's generic database type collapsing to never.
+let _supabase: any = null
+function getSupabase() {
+  if (_supabase) return _supabase
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    throw new Error('Supabase not configured: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing')
+  }
+  _supabase = createClient(url, key)
+  return _supabase
+}
 
 const SITE_ID = process.env.NEXT_PUBLIC_SITE_ID || 'seniorsimple'
 
@@ -51,6 +61,8 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       )
     }
+
+    const supabase = getSupabase()
 
     // Check if subscriber already exists
     const { data: existing } = await supabase

--- a/src/app/api/unsubscribe/route.ts
+++ b/src/app/api/unsubscribe/route.ts
@@ -1,10 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
+// Lazy-init: see /api/poll/route.ts for full rationale. Module-load createClient
+// throws "supabaseKey is required" during `next build` when env var is missing.
+// Typed `any` to avoid createClient's generic database type collapsing to never.
+let _supabase: any = null
+function getSupabase() {
+  if (_supabase) return _supabase
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    throw new Error('Supabase not configured: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing')
+  }
+  _supabase = createClient(url, key)
+  return _supabase
+}
 
 const SITE_ID = process.env.NEXT_PUBLIC_SITE_ID || 'seniorsimple'
 
@@ -31,6 +41,7 @@ export async function GET(request: NextRequest) {
   const email = searchParams.get('email')
   const site = searchParams.get('site') || SITE_ID
 
+  const supabase = getSupabase()
   let subscriber: { id: string; status: string; site_id: string } | null = null
 
   if (sid) {
@@ -76,6 +87,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
     const { subscriber_id, email, site_id } = body
 
+    const supabase = getSupabase()
     let targetId = subscriber_id
 
     if (!targetId && email) {

--- a/src/app/poll/results/page.tsx
+++ b/src/app/poll/results/page.tsx
@@ -1,9 +1,18 @@
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
+// Lazy-init: createClient at module load throws "supabaseKey is required" during
+// `next build` page-data collection when env var is missing. Defer to render.
+let _supabase: any = null
+function getSupabase() {
+  if (_supabase) return _supabase
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !key) {
+    throw new Error('Supabase not configured: NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY missing')
+  }
+  _supabase = createClient(url, key)
+  return _supabase
+}
 
 interface PollResult {
   answer_value: string
@@ -44,6 +53,8 @@ export default async function PollResultsPage({
       </div>
     )
   }
+
+  const supabase = getSupabase()
 
   // Resolve issue_id
   const { data: issue } = await supabase

--- a/src/app/reverse-mortgage-calculator/not-qualified/page.tsx
+++ b/src/app/reverse-mortgage-calculator/not-qualified/page.tsx
@@ -31,6 +31,12 @@ function NotQualifiedContent() {
         message: "To qualify for a reverse mortgage, you must own your home and live in it as your primary residence. If you're planning to purchase a home, you may want to explore other financing options.",
       }
     }
+    if (reason === 'ltv') {
+      return {
+        title: "We're sorry, but you don't currently qualify",
+        message: "Based on the numbers you confirmed, your existing mortgage balance is too high relative to your home's value for a reverse mortgage. HECM proceeds need to be sufficient to pay off your current loan in full at closing. If you're able to pay down your mortgage, or if your home value has increased recently, you may qualify in the future.",
+      }
+    }
     return {
       title: "We're sorry, but you don't currently qualify",
       message: "Based on your responses, you don't currently meet the eligibility requirements for a reverse mortgage.",

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -713,25 +713,47 @@ export default function ReverseMortgageCalculatorPage() {
       // Both events use the same pixel + CAPI. The gate decision and event IDs
       // were generated upfront (before fetch) so server CAPI can dedup against
       // these browser pixel events.
+      // sessionStorage dedup: each Meta event fires at most once per browser tab.
+      // Eliminates the 2.5× over-reporting observed when users refresh / back-button
+      // / resubmit and the browser pixel fires again with a fresh eventID (server
+      // CAPI dedup can't help when each fire uses a different eventID).
+      const LEAD_FIRED_KEY = 'rm_meta_lead_fired'
+      const QUAL_FIRED_KEY = 'rm_meta_qualified_lead_fired'
+      const leadAlreadyFired = typeof window !== 'undefined'
+        && sessionStorage.getItem(LEAD_FIRED_KEY) === '1'
+      const qualAlreadyFired = typeof window !== 'undefined'
+        && sessionStorage.getItem(QUAL_FIRED_KEY) === '1'
+
       console.log('[Meta CAPI] Dual-event firing', {
         leadEventId: capiEventId,
         qualifiedLeadEventId,
         gatingLtv,
         fireQualifiedLead,
+        leadAlreadyFired,
+        qualAlreadyFired,
       })
 
-      // Lead event (fires for everyone — current campaign signal)
-      trackMetaPixelEvent('Lead', {
-        content_name: 'Reverse Mortgage Lead',
-        content_category: 'reverse-mortgage',
-        value: 0,
-        currency: 'USD',
-        ltv: gatingLtv > 0 ? Number(gatingLtv.toFixed(4)) : undefined,
-        ltv_source: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
-      }, 'reverse-mortgage', capiEventId)
+      // Lead event (fires for everyone — current campaign signal). sessionStorage
+      // guard prevents refires within the same browser tab.
+      if (!leadAlreadyFired) {
+        trackMetaPixelEvent('Lead', {
+          content_name: 'Reverse Mortgage Lead',
+          content_category: 'reverse-mortgage',
+          value: 0,
+          currency: 'USD',
+          ltv: gatingLtv > 0 ? Number(gatingLtv.toFixed(4)) : undefined,
+          ltv_source: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
+        }, 'reverse-mortgage', capiEventId)
+        if (typeof window !== 'undefined') {
+          sessionStorage.setItem(LEAD_FIRED_KEY, '1')
+        }
+      } else {
+        console.log('[Meta CAPI] ⏭️ Skipping browser Lead pixel — already fired this session')
+      }
 
       // QualifiedLead custom event (only LTV ≤ 50% — high-equity, future campaign signal)
-      if (fireQualifiedLead && qualifiedLeadEventId && typeof window !== 'undefined' && (window as any).fbq) {
+      if (fireQualifiedLead && qualifiedLeadEventId && !qualAlreadyFired
+          && typeof window !== 'undefined' && (window as any).fbq) {
         (window as any).fbq('trackCustom', 'QualifiedLead', {
           content_name: 'Reverse Mortgage Qualified Lead (LTV≤50% / equity≥50%)',
           content_category: 'reverse-mortgage',
@@ -741,6 +763,9 @@ export default function ReverseMortgageCalculatorPage() {
           ltv_source: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
           funnel_type: 'reverse-mortgage',
         }, { eventID: qualifiedLeadEventId })
+        sessionStorage.setItem(QUAL_FIRED_KEY, '1')
+      } else if (fireQualifiedLead && qualAlreadyFired) {
+        console.log('[Meta CAPI] ⏭️ Skipping browser QualifiedLead pixel — already fired this session')
       }
       
       console.log('📊 Lead Submitted Successfully:', {

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -94,11 +94,13 @@ export default function ReverseMortgageCalculatorPage() {
   const [lookupError, setLookupError] = useState('')
   const [isLookupLoading, setIsLookupLoading] = useState(false)
   // User-verified (or BatchData-trusted) property values captured at step 5.
-  // Required to reach step 6 (lead capture); leads with LTV>35% never reach this state.
+  // `batchDataLtv` is the original BatchData LTV before user adjustment — used for
+  // defensive max(batchData, userVerified) gating downstream (e.g. Meta CAPI).
   const [verifiedProperty, setVerifiedProperty] = useState<{
     propertyValue: number
     mortgageBalance: number
     ltv: number
+    batchDataLtv?: number
     batchDataUsed: boolean
   } | null>(null)
 
@@ -378,6 +380,7 @@ export default function ReverseMortgageCalculatorPage() {
     propertyValue: number
     mortgageBalance: number
     ltv: number
+    batchDataLtv?: number
     batchDataUsed: boolean
   }) => {
     setVerifiedProperty(values)
@@ -477,6 +480,7 @@ export default function ReverseMortgageCalculatorPage() {
             propertyValue: verifiedProperty.propertyValue,
             mortgageBalance: verifiedProperty.mortgageBalance,
             ltv: verifiedProperty.ltv,
+            batchDataLtv: verifiedProperty.batchDataLtv,
             batchDataUsed: verifiedProperty.batchDataUsed,
           }
         : null,
@@ -558,6 +562,18 @@ export default function ReverseMortgageCalculatorPage() {
     // Generate shared eventID for browser pixel + server CAPI deduplication
     const capiEventId = `lead-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
+    // Decide whether to also fire the QualifiedLead custom event (≥50% LTV).
+    // Generated upfront so browser pixel and server CAPI can use the same eventID for dedup.
+    const QUALIFIED_LEAD_LTV_FLOOR = 0.50
+    const gatingLtv = Math.max(
+      verifiedProperty?.ltv ?? 0,
+      verifiedProperty?.batchDataLtv ?? 0,
+    )
+    const fireQualifiedLead = gatingLtv >= QUALIFIED_LEAD_LTV_FLOOR
+    const qualifiedLeadEventId = fireQualifiedLead
+      ? `qlead-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      : undefined
+
     const payload = {
       email,
       phoneNumber: formatPhoneForGHL(extractUSPhoneNumber(phone)),
@@ -578,8 +594,20 @@ export default function ReverseMortgageCalculatorPage() {
         fbc: metaCookies.fbc,
         fbLoginId: fbLoginId,
       },
-      // Shared eventID for browser+server CAPI dedup
+      // Shared eventID for browser+server CAPI dedup (Lead event — fires for everyone)
       capiEventId,
+      // QualifiedLead custom event — only when LTV >= 0.50 (≥50% LTV). When this
+      // eventId is set, the server fires a matching CAPI QualifiedLead event with
+      // it for browser/server dedup. When undefined, the server skips the event.
+      // This is the dual-event setup: Lead optimizes the current campaign, while
+      // QualifiedLead builds the optimization signal for a future duplicate campaign.
+      qualifiedLeadEventId,
+      qualifiedLeadGate: {
+        gatingLtv: Number(gatingLtv.toFixed(4)),
+        floor: QUALIFIED_LEAD_LTV_FLOOR,
+        shouldFire: fireQualifiedLead,
+        ltvSource: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
+      },
     }
     console.log('[DEBUG] 🔵 Payload prepared for submission', { 
       trustedFormCertUrl: payload.trustedFormCertUrl || 'NULL', 
@@ -669,13 +697,46 @@ export default function ReverseMortgageCalculatorPage() {
         event_category: 'reverse_mortgage_funnel'
       })
       
-      // Track to Meta - Lead event (browser pixel with shared eventID for CAPI dedup)
+      // ────────────────────────────────────────────────────────────────────────
+      // Meta dual-event strategy
+      // ────────────────────────────────────────────────────────────────────────
+      // 1) `Lead` — fires for EVERY submitted lead (unchanged behavior). Current
+      //    campaign keeps optimizing on full volume; do not break it.
+      // 2) `QualifiedLead` — custom event, fires only when LTV >= 50%. Builds
+      //    the optimization signal for a duplicated Meta campaign that will
+      //    optimize on higher-intent leads once it accumulates ~50 events/week.
+      // Both events use the same pixel + CAPI. The gate decision and event IDs
+      // were generated upfront (before fetch) so server CAPI can dedup against
+      // these browser pixel events.
+      console.log('[Meta CAPI] Dual-event firing', {
+        leadEventId: capiEventId,
+        qualifiedLeadEventId,
+        gatingLtv,
+        fireQualifiedLead,
+      })
+
+      // Lead event (fires for everyone — current campaign signal)
       trackMetaPixelEvent('Lead', {
         content_name: 'Reverse Mortgage Lead',
         content_category: 'reverse-mortgage',
-        value: 0, // Value will be calculated on results page
-        currency: 'USD'
+        value: 0,
+        currency: 'USD',
+        ltv: gatingLtv > 0 ? Number(gatingLtv.toFixed(4)) : undefined,
+        ltv_source: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
       }, 'reverse-mortgage', capiEventId)
+
+      // QualifiedLead custom event (only ≥50% LTV — future campaign signal)
+      if (fireQualifiedLead && qualifiedLeadEventId && typeof window !== 'undefined' && (window as any).fbq) {
+        (window as any).fbq('trackCustom', 'QualifiedLead', {
+          content_name: 'Reverse Mortgage Qualified Lead (LTV≥50%)',
+          content_category: 'reverse-mortgage',
+          value: 0,
+          currency: 'USD',
+          ltv: Number(gatingLtv.toFixed(4)),
+          ltv_source: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
+          funnel_type: 'reverse-mortgage',
+        }, { eventID: qualifiedLeadEventId })
+      }
       
       console.log('📊 Lead Submitted Successfully:', {
         sessionId,

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -678,18 +678,24 @@ export default function ReverseMortgageCalculatorPage() {
       // Track quiz complete
       trackQuizComplete('reverse-mortgage', sessionId, 'reverse-mortgage', completionTime)
       
-      // Track lead form submit
-      trackLeadFormSubmit({
-        firstName,
-        lastName,
-        email,
-        phoneNumber: formatPhoneForGHL(extractUSPhoneNumber(phone)),
-        zipCode: address?.zip || '',
-        state: address?.state,
-        quizAnswers,
-        sessionId,
-        funnelType: 'reverse-mortgage'
-      })
+      // Track lead form submit — but suppress the embedded Meta Lead pixel fire.
+      // We fire Lead explicitly below with capiEventId so it dedupes against the
+      // server CAPI Lead event. If we let trackLeadFormSubmit also fire Lead (no
+      // eventID), Meta would count two separate Lead events per submit.
+      trackLeadFormSubmit(
+        {
+          firstName,
+          lastName,
+          email,
+          phoneNumber: formatPhoneForGHL(extractUSPhoneNumber(phone)),
+          zipCode: address?.zip || '',
+          state: address?.state,
+          quizAnswers,
+          sessionId,
+          funnelType: 'reverse-mortgage',
+        },
+        { skipMetaEvent: true },
+      )
       
       // Track to GA4
       trackGA4Event('rm_lead_submitted', {

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -782,7 +782,11 @@ export default function ReverseMortgageCalculatorPage() {
 
       // Route based on buyer-1 fit. >35% LTV leads land on /results-alt so we can
       // segment them downstream for offer-wall / alt-buyer routing.
-      const isBuyer1Fit = !!verifiedProperty && verifiedProperty.ltv <= MAX_QUALIFYING_LTV
+      // Gated behind NEXT_PUBLIC_RM_LTV_GATE — when off (default), every lead
+      // routes to /results regardless of LTV (preserves current LynqFlux volume).
+      const LTV_GATE_ENABLED = process.env.NEXT_PUBLIC_RM_LTV_GATE === 'on'
+      const isBuyer1Fit = !LTV_GATE_ENABLED
+        || (!!verifiedProperty && verifiedProperty.ltv <= MAX_QUALIFYING_LTV)
       router.push(
         isBuyer1Fit
           ? '/reverse-mortgage-calculator/results'

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, useCallback } from 'react'
+import { PropertyVerificationStep } from '@/components/reverse-mortgage/PropertyVerificationStep'
+import { MAX_QUALIFYING_LTV } from '@/components/reverse-mortgage/VerifyPropertyDetails'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import Image from 'next/image'
@@ -91,6 +93,14 @@ export default function ReverseMortgageCalculatorPage() {
   const [calculation, setCalculation] = useState<ReverseMortgageCalculation | null>(null)
   const [lookupError, setLookupError] = useState('')
   const [isLookupLoading, setIsLookupLoading] = useState(false)
+  // User-verified (or BatchData-trusted) property values captured at step 5.
+  // Required to reach step 6 (lead capture); leads with LTV>35% never reach this state.
+  const [verifiedProperty, setVerifiedProperty] = useState<{
+    propertyValue: number
+    mortgageBalance: number
+    ltv: number
+    batchDataUsed: boolean
+  } | null>(null)
 
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
@@ -113,14 +123,17 @@ export default function ReverseMortgageCalculatorPage() {
   const [stepStartTime, setStepStartTime] = useState<number>(Date.now())
   const [quizStartTime, setQuizStartTime] = useState<number>(Date.now())
 
-  // Step names for tracking (5 steps - property lookup moved to results page)
+  // Step names for tracking (6 steps — property verification moved BEFORE lead capture
+  // so leads that fail the 35% LTV gate never become captured leads).
   const STEP_NAMES: Record<number, string> = {
     1: 'homeowner_check',
     2: 'age_verification',
     3: 'reason_selection',
     4: 'address_entry',
-    5: 'lead_capture'
+    5: 'property_verification',
+    6: 'lead_capture',
   }
+  const TOTAL_STEPS = 6
 
   // Log quiz progress to Vercel runtime logs (fire-and-forget)
   const logQuizProgress = (stepNum: number, stepName: string, answer: string, meta?: Record<string, any>) => {
@@ -133,7 +146,7 @@ export default function ReverseMortgageCalculatorPage() {
         step: stepNum,
         stepName,
         answer,
-        totalSteps: 5,
+        totalSteps: TOTAL_STEPS,
         meta,
       }),
     }).catch(() => {})
@@ -192,7 +205,7 @@ export default function ReverseMortgageCalculatorPage() {
       event_category: 'reverse_mortgage_funnel'
     })
     
-    // Track to Meta for retargeting audiences (5-step funnel)
+    // Track to Meta for retargeting audiences (6-step funnel)
     if (step === 4) {
       // Address entry step - high intent
       trackMetaPixelEvent('ViewContent', {
@@ -201,7 +214,14 @@ export default function ReverseMortgageCalculatorPage() {
         value: 0
       }, 'reverse-mortgage')
     } else if (step === 5) {
-      // Lead form - intent to convert
+      // Property verification step — user is engaging with their numbers
+      trackMetaPixelEvent('ViewContent', {
+        content_name: 'Reverse Mortgage - Property Verification',
+        content_category: 'reverse-mortgage',
+        value: 0,
+      }, 'reverse-mortgage')
+    } else if (step === 6) {
+      // Lead form - intent to convert (only reached by user-verified ≤35% LTV)
       trackMetaPixelEvent('InitiateCheckout', {
         content_name: 'Reverse Mortgage - Lead Form',
         content_category: 'reverse-mortgage',
@@ -223,10 +243,10 @@ export default function ReverseMortgageCalculatorPage() {
     setStepStartTime(Date.now())
   }, [step, sessionId])
 
-  // Load TrustedForm script ONLY when form is visible (step 5)
+  // Load TrustedForm script ONLY when form is visible (step 6 in the new flow)
   // This ensures the form field exists BEFORE the script loads
   // TrustedForm script must find the form field at initialization time
-  useTrustedForm({ enabled: step === 5 })
+  useTrustedForm({ enabled: step === 6 })
 
   const emailValidationState = useMemo(() => getEmailValidationState(email), [email])
   const phoneValidationState = useMemo(() => getPhoneValidationState(phone), [phone])
@@ -335,8 +355,62 @@ export default function ReverseMortgageCalculatorPage() {
       return
     }
 
-    // Move directly to lead capture - property lookup happens on results page
+    // Move to the property verification step. BatchData lookup fires there.
     setStep(5)
+  }
+
+  // Stable callback for PropertyVerificationStep — keeps its useEffect from re-firing.
+  const handleLookupComplete = useCallback(
+    (info: { success: boolean; ms: number; ltv?: number }) => {
+      logQuizProgress(5, 'batchdata_lookup', info.success ? 'success' : 'failed', info)
+      trackGA4Event('rm_property_lookup', {
+        success: info.success,
+        latency_ms: info.ms,
+        batchdata_ltv: info.ltv,
+      })
+    },
+    // sessionId comes from closure; logQuizProgress is stable enough for our purposes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [sessionId],
+  )
+
+  const handlePropertyVerified = (values: {
+    propertyValue: number
+    mortgageBalance: number
+    ltv: number
+    batchDataUsed: boolean
+  }) => {
+    setVerifiedProperty(values)
+    const ltvPct = Math.round(values.ltv * 100)
+    const qualifiesBuyer1 = values.ltv <= MAX_QUALIFYING_LTV
+
+    logQuizProgress(
+      5,
+      'property_verification',
+      `ltv=${ltvPct}% ${qualifiesBuyer1 ? 'buyer1_fit' : 'buyer1_dq'}`,
+      {
+        propertyValue: values.propertyValue,
+        mortgageBalance: values.mortgageBalance,
+        ltv: values.ltv,
+        batchDataUsed: values.batchDataUsed,
+        qualifiesBuyer1,
+      },
+    )
+
+    trackGA4Event('rm_property_verified', {
+      ltv: Number(values.ltv.toFixed(4)),
+      qualifies_buyer1: qualifiesBuyer1,
+      batch_data_used: values.batchDataUsed,
+      property_value: values.propertyValue,
+      mortgage_balance: values.mortgageBalance,
+      session_id: sessionId,
+    })
+
+    // No hard DQ here — every verified lead advances to lead capture. Buyer-1 fit is
+    // recorded on the lead in state; post-submit routing branches on it to send
+    // qualifying leads to /results (LynqFlux) and DQ leads to /results-alt (alt buyer
+    // / offer-wall placeholder).
+    setStep(6)
   }
 
   const handleLeadSubmit = async (event: React.FormEvent) => {
@@ -397,7 +471,15 @@ export default function ReverseMortgageCalculatorPage() {
         state: address.state,
         zipCode: address.zip,
       },
-      // Note: propertyData and calculation will be fetched on results page
+      // User-verified at step 5 (always present when we reach lead submit; LTV is ≤35%).
+      verifiedProperty: verifiedProperty
+        ? {
+            propertyValue: verifiedProperty.propertyValue,
+            mortgageBalance: verifiedProperty.mortgageBalance,
+            ltv: verifiedProperty.ltv,
+            batchDataUsed: verifiedProperty.batchDataUsed,
+          }
+        : null,
       funnelType: 'reverse-mortgage',
     }
 
@@ -521,17 +603,17 @@ export default function ReverseMortgageCalculatorPage() {
         throw new Error(data?.error || 'Failed to submit your request.')
       }
 
-      // Store data for results page - property lookup will happen there
+      // Store data for results page — property already verified at step 5, so the
+      // results page can skip BatchData and go straight to delivery + results.
       const stored = {
         ...quizAnswers,
-        sessionId, // Needed for LynqFlux delivery after BatchData
+        sessionId, // Needed for LynqFlux delivery
         contact: {
           firstName,
           lastName,
           email,
           phone: formatPhoneForGHL(extractUSPhoneNumber(phone)),
         },
-        // Address info for property lookup on results page
         addressForLookup: {
           street: address.street,
           city: address.city,
@@ -539,7 +621,17 @@ export default function ReverseMortgageCalculatorPage() {
           zip: address.zip,
           fullAddress: address.formatted_address,
         },
-        age, // Needed for calculation on results page
+        age,
+        // Verified property carried across the page boundary so /results can render
+        // and deliver immediately, without a second BatchData round-trip.
+        verifiedProperty: verifiedProperty
+          ? {
+              propertyValue: verifiedProperty.propertyValue,
+              mortgageBalance: verifiedProperty.mortgageBalance,
+              ltv: verifiedProperty.ltv,
+              batchDataUsed: verifiedProperty.batchDataUsed,
+            }
+          : null,
         submittedAt: new Date().toISOString(),
       }
 
@@ -591,7 +683,14 @@ export default function ReverseMortgageCalculatorPage() {
         address: address.formatted_address
       })
 
-      router.push('/reverse-mortgage-calculator/results')
+      // Route based on buyer-1 fit. >35% LTV leads land on /results-alt so we can
+      // segment them downstream for offer-wall / alt-buyer routing.
+      const isBuyer1Fit = !!verifiedProperty && verifiedProperty.ltv <= MAX_QUALIFYING_LTV
+      router.push(
+        isBuyer1Fit
+          ? '/reverse-mortgage-calculator/results'
+          : '/reverse-mortgage-calculator/results-alt',
+      )
     } catch (error: any) {
       console.error('Lead submission failed:', error)
       
@@ -635,13 +734,13 @@ export default function ReverseMortgageCalculatorPage() {
             {/* Progress Bar */}
             <div className="mb-6">
               <div className="flex items-center justify-between text-sm mb-2">
-                <span className="font-semibold text-[#36596A]">Step {step} of 5</span>
+                <span className="font-semibold text-[#36596A]">Step {step} of {TOTAL_STEPS}</span>
                 <span className="text-gray-500">Fast, no-obligation estimate</span>
               </div>
               <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
-                <div 
+                <div
                   className="h-full bg-gradient-to-r from-[#36596A] to-[#4a7a8a] rounded-full transition-all duration-300"
-                  style={{ width: `${(step / 5) * 100}%` }}
+                  style={{ width: `${(step / TOTAL_STEPS) * 100}%` }}
                 />
               </div>
             </div>
@@ -817,7 +916,20 @@ export default function ReverseMortgageCalculatorPage() {
               </div>
             )}
 
-            {step === 5 && (
+            {step === 5 && address && (
+              <PropertyVerificationStep
+                address={{
+                  street: address.street,
+                  city: address.city,
+                  state: address.state,
+                  zip: address.zip,
+                }}
+                onConfirm={handlePropertyVerified}
+                onLookupComplete={handleLookupComplete}
+              />
+            )}
+
+            {step === 6 && (
               <div className="space-y-6">
                 <div className="text-center">
                   <h2 className="text-2xl sm:text-3xl font-bold text-gray-900">

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -562,14 +562,18 @@ export default function ReverseMortgageCalculatorPage() {
     // Generate shared eventID for browser pixel + server CAPI deduplication
     const capiEventId = `lead-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
 
-    // Decide whether to also fire the QualifiedLead custom event (≥50% LTV).
-    // Generated upfront so browser pixel and server CAPI can use the same eventID for dedup.
-    const QUALIFIED_LEAD_LTV_FLOOR = 0.50
+    // Decide whether to also fire the QualifiedLead custom event.
+    // Low LTV = high equity = lead the buyer actually wants. Gate fires when LTV
+    // is at or below the ceiling (≤ 0.50 = ≥50% equity).
+    // Defensive: take max(BatchData, user-verified) so users adjusting numbers
+    // downward at step 5 can't game their way into the qualified bucket.
+    // Generated upfront so browser pixel and server CAPI use the same eventID for dedup.
+    const QUALIFIED_LEAD_LTV_CEILING = 0.50
     const gatingLtv = Math.max(
       verifiedProperty?.ltv ?? 0,
       verifiedProperty?.batchDataLtv ?? 0,
     )
-    const fireQualifiedLead = gatingLtv >= QUALIFIED_LEAD_LTV_FLOOR
+    const fireQualifiedLead = gatingLtv > 0 && gatingLtv <= QUALIFIED_LEAD_LTV_CEILING
     const qualifiedLeadEventId = fireQualifiedLead
       ? `qlead-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
       : undefined
@@ -604,7 +608,7 @@ export default function ReverseMortgageCalculatorPage() {
       qualifiedLeadEventId,
       qualifiedLeadGate: {
         gatingLtv: Number(gatingLtv.toFixed(4)),
-        floor: QUALIFIED_LEAD_LTV_FLOOR,
+        ceiling: QUALIFIED_LEAD_LTV_CEILING,
         shouldFire: fireQualifiedLead,
         ltvSource: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
       },
@@ -702,8 +706,9 @@ export default function ReverseMortgageCalculatorPage() {
       // ────────────────────────────────────────────────────────────────────────
       // 1) `Lead` — fires for EVERY submitted lead (unchanged behavior). Current
       //    campaign keeps optimizing on full volume; do not break it.
-      // 2) `QualifiedLead` — custom event, fires only when LTV >= 50%. Builds
-      //    the optimization signal for a duplicated Meta campaign that will
+      // 2) `QualifiedLead` — custom event, fires only when LTV ≤ 50% (i.e.
+      //    ≥50% equity, the leads the buyer actually wants). Builds the
+      //    optimization signal for a duplicated Meta campaign that will
       //    optimize on higher-intent leads once it accumulates ~50 events/week.
       // Both events use the same pixel + CAPI. The gate decision and event IDs
       // were generated upfront (before fetch) so server CAPI can dedup against
@@ -725,10 +730,10 @@ export default function ReverseMortgageCalculatorPage() {
         ltv_source: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
       }, 'reverse-mortgage', capiEventId)
 
-      // QualifiedLead custom event (only ≥50% LTV — future campaign signal)
+      // QualifiedLead custom event (only LTV ≤ 50% — high-equity, future campaign signal)
       if (fireQualifiedLead && qualifiedLeadEventId && typeof window !== 'undefined' && (window as any).fbq) {
         (window as any).fbq('trackCustom', 'QualifiedLead', {
-          content_name: 'Reverse Mortgage Qualified Lead (LTV≥50%)',
+          content_name: 'Reverse Mortgage Qualified Lead (LTV≤50% / equity≥50%)',
           content_category: 'reverse-mortgage',
           value: 0,
           currency: 'USD',

--- a/src/app/reverse-mortgage-calculator/results-alt/page.tsx
+++ b/src/app/reverse-mortgage-calculator/results-alt/page.tsx
@@ -1,0 +1,194 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { CheckCircle } from 'lucide-react'
+import { useFunnelLayout } from '@/hooks/useFunnelFooter'
+import { initializeTracking, trackPageView, trackGA4Event } from '@/lib/temp-tracking'
+import { FAQ } from '@/components/quiz/FAQ'
+
+/**
+ * Alt thank-you for reverse-mortgage leads that don't fit Buyer 1 (LTV > 35%).
+ *
+ * The lead is captured in the DB but never sent to LynqFlux. This page:
+ *   1. Tags the lead with ghl_status.buyer1_dq so we can segment downstream
+ *   2. Shows a warm, neutral thank-you (no specific equity promise)
+ *   3. Acts as the future surface for an offer wall / alt-buyer routing
+ *
+ * Future enhancements (not yet wired):
+ *   - Affiliate offer wall (debt consolidation, refi, HELOC, credit repair)
+ *   - Direct route to a secondary mortgage buyer that accepts higher LTV
+ *   - Email nurture sequence with content tailored to high-LTV homeowners
+ */
+
+const STORAGE_KEY = 'reverse_mortgage_calculator'
+
+interface StoredResults {
+  sessionId?: string
+  contact?: { firstName?: string; lastName?: string; email?: string; phone?: string }
+  verifiedProperty?: {
+    propertyValue: number
+    mortgageBalance: number
+    ltv: number
+    batchDataUsed: boolean
+  } | null
+}
+
+export default function ReverseMortgageResultsAltPage() {
+  useFunnelLayout()
+  const router = useRouter()
+  const [firstName, setFirstName] = useState<string>('')
+  const [tagged, setTagged] = useState<'pending' | 'done' | 'skipped'>('pending')
+
+  useEffect(() => {
+    initializeTracking()
+    trackPageView(
+      'Reverse Mortgage Results — Alt (Buyer 1 DQ)',
+      '/reverse-mortgage-calculator/results-alt',
+    )
+
+    if (typeof window === 'undefined') return
+    const stored = sessionStorage.getItem(STORAGE_KEY) || localStorage.getItem(STORAGE_KEY)
+    if (!stored) {
+      setTagged('skipped')
+      return
+    }
+
+    let parsed: StoredResults
+    try {
+      parsed = JSON.parse(stored) as StoredResults
+    } catch {
+      setTagged('skipped')
+      return
+    }
+
+    setFirstName(parsed.contact?.firstName || '')
+
+    trackGA4Event('rm_alt_thank_you_shown', {
+      ltv: parsed.verifiedProperty?.ltv,
+      property_value: parsed.verifiedProperty?.propertyValue,
+      mortgage_balance: parsed.verifiedProperty?.mortgageBalance,
+      batch_data_used: parsed.verifiedProperty?.batchDataUsed,
+      reason: 'ltv_above_35',
+    })
+
+    const vp = parsed.verifiedProperty
+    if (parsed.sessionId && vp) {
+      fetch('/api/leads/mark-buyer1-dq', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: parsed.sessionId,
+          propertyValue: vp.propertyValue,
+          mortgageBalance: vp.mortgageBalance,
+          ltv: vp.ltv,
+          batchDataUsed: vp.batchDataUsed,
+        }),
+      })
+        .then((r) => r.json())
+        .then((r) => {
+          if (r.success) {
+            console.log('🟠 Buyer-1 DQ recorded for lead', r.leadId)
+            setTagged('done')
+          } else {
+            console.warn('🔴 Buyer-1 DQ tag failed:', r)
+            setTagged('done') // still show the page; tag failure is non-blocking for UX
+          }
+        })
+        .catch((err) => {
+          console.error('Buyer-1 DQ tag error:', err)
+          setTagged('done')
+        })
+    } else {
+      setTagged('skipped')
+    }
+  }, [])
+
+  return (
+    <div className="min-h-screen bg-[#F5F5F0]">
+      <section className="py-10 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="bg-white rounded-2xl shadow-lg border border-[#E5E7EB] p-6 sm:p-8">
+            <div className="text-center space-y-4">
+              <div className="mx-auto h-14 w-14 rounded-full bg-green-100 flex items-center justify-center">
+                <CheckCircle className="h-8 w-8 text-green-600" />
+              </div>
+              <h1 className="text-3xl sm:text-4xl font-serif font-semibold text-[#36596A]">
+                Thank You, {firstName || 'Friend'}!
+              </h1>
+              <p className="text-gray-600">
+                Your information has been received. A licensed specialist will review your
+                situation and reach out to discuss the right options for you.
+              </p>
+            </div>
+
+            <div className="mt-8 bg-slate-50 rounded-2xl p-6">
+              <div className="max-w-md mx-auto text-center">
+                <img
+                  src="/images/team/agent-advisor.png"
+                  alt="Licensed Specialist"
+                  className="w-full max-w-sm mx-auto mb-4 object-cover rounded-lg"
+                />
+                <h3 className="text-xl font-semibold text-slate-800 mb-2">
+                  Your Licensed Specialist
+                </h3>
+                <p className="text-slate-600 text-sm">
+                  A licensed specialist will review your property details and provide
+                  personalized guidance on the programs that fit your situation.
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-8 space-y-4 text-sm text-gray-700">
+              <h2 className="text-lg font-semibold text-gray-900">What happens next</h2>
+              <div className="space-y-3">
+                <div className="flex items-start gap-3">
+                  <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
+                  <span>
+                    <strong>Within 24 hours:</strong> A licensed specialist will call to discuss
+                    your options and answer all your questions.
+                  </span>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
+                  <span>
+                    <strong>Custom Review:</strong> Your specialist will review your property
+                    details and walk through the programs that fit your situation.
+                  </span>
+                </div>
+                <div className="flex items-start gap-3">
+                  <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
+                  <span>
+                    <strong>Your Decision:</strong> No pressure — take time to review your
+                    options and decide what's right for you.
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-8 rounded-xl border border-gray-200 bg-gray-50 p-5 text-sm text-gray-700">
+              <p>
+                Questions? Call us at{' '}
+                <a href="tel:+18585046544" className="font-semibold text-[#36596A]">
+                  (858) 504-6544
+                </a>
+                .
+              </p>
+            </div>
+
+            <div className="mt-8 text-center">
+              <button
+                onClick={() => router.push('/reverse-mortgage-calculator')}
+                className="text-sm font-semibold text-[#36596A] hover:underline"
+              >
+                Run another estimate
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <FAQ funnelType="reverse-mortgage-calculator" />
+    </div>
+  )
+}

--- a/src/app/reverse-mortgage-calculator/results/page.tsx
+++ b/src/app/reverse-mortgage-calculator/results/page.tsx
@@ -36,6 +36,13 @@ interface StoredResults {
   age?: number
   submittedAt?: string
   reason?: string
+  /** Set by the quiz at step 5 when the new pre-contact verify flow is in use. */
+  verifiedProperty?: {
+    propertyValue: number
+    mortgageBalance: number
+    ltv: number
+    batchDataUsed: boolean
+  } | null
 }
 
 interface PropertyData {
@@ -222,6 +229,39 @@ export default function ReverseMortgageResultsPage() {
       const city = addressForLookup?.city || addressInfo?.city
       const state = addressForLookup?.state || addressInfo?.state
       const zipCode = addressForLookup?.zip || addressInfo?.zipCode || addressInfo?.zip
+
+      // Fast path: quiz already verified property at step 5 (new flow). Deliver immediately
+      // and render results — skip BatchData entirely. Any lead reaching here has LTV ≤ 35%
+      // (the quiz routes >35% to /not-qualified before the lead is captured).
+      const vp = parsedResults.verifiedProperty
+      if (vp) {
+        console.log('⚡ Using verifiedProperty from quiz step 5, skipping BatchData lookup')
+        const age = parsedResults.age || 70
+        const calc = calculateReverseMortgage(
+          {
+            property_value: vp.propertyValue,
+            mortgage_balance: vp.mortgageBalance,
+            equity_available: Math.max(0, vp.propertyValue - vp.mortgageBalance),
+          },
+          age,
+        )
+        setCalculation(calc)
+        setPhase('results')
+        deliverAndTrack({
+          sessionId: parsedResults.sessionId,
+          contact: parsedResults.contact,
+          propertyValue: vp.propertyValue,
+          mortgageBalance: vp.mortgageBalance,
+          ltvRatio: vp.ltv,
+          city,
+          state,
+          zipCode,
+          netProceeds: calc.netProceeds,
+          equityAvailable: calc.equityAvailable,
+          source: vp.batchDataUsed ? 'batchdata' : 'user_verified',
+        })
+        return
+      }
 
       if (!street || !city || !state) {
         console.log('No address data for property lookup → verify screen')

--- a/src/app/reverse-mortgage-calculator/results/page.tsx
+++ b/src/app/reverse-mortgage-calculator/results/page.tsx
@@ -6,6 +6,7 @@ import { CheckCircle, Loader2 } from 'lucide-react'
 import { useFunnelLayout } from '@/hooks/useFunnelFooter'
 import { initializeTracking, trackPageView, trackGA4Event } from '@/lib/temp-tracking'
 import { FAQ } from '@/components/quiz/FAQ'
+import { VerifyPropertyDetails, MAX_QUALIFYING_LTV } from '@/components/reverse-mortgage/VerifyPropertyDetails'
 
 const STORAGE_KEY = 'reverse_mortgage_calculator'
 
@@ -79,13 +80,113 @@ const calculateReverseMortgage = (data: PropertyData, age: number): CalculationR
   }
 }
 
+type Phase = 'loading' | 'results' | 'verify' | 'submitting_verify'
+
 export default function ReverseMortgageResultsPage() {
   useFunnelLayout()
   const router = useRouter()
   const [results, setResults] = useState<StoredResults | null>(null)
   const [calculation, setCalculation] = useState<CalculationResult | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [lookupStatus, setLookupStatus] = useState<'loading' | 'success' | 'failed'>('loading')
+  const [phase, setPhase] = useState<Phase>('loading')
+  const [batchData, setBatchData] = useState<{ property?: PropertyData; state?: string; lookupFailed: boolean }>({
+    lookupFailed: false,
+  })
+
+  // Fire LynqFlux delivery + Meta CAPI ViewContent with the given property values.
+  // Used for both the BatchData-trusted path and the user-verified path.
+  const deliverAndTrack = (args: {
+    sessionId?: string
+    contact?: StoredResults['contact']
+    propertyValue: number
+    mortgageBalance: number
+    ltvRatio: number
+    city?: string
+    state?: string
+    zipCode?: string
+    netProceeds: number
+    equityAvailable: number
+    source: 'batchdata' | 'user_verified'
+  }) => {
+    const getCookie = (name: string) => {
+      const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'))
+      return match ? match[2] : undefined
+    }
+
+    trackGA4Event('rm_results_property_found', {
+      property_value: args.propertyValue,
+      equity_available: args.equityAvailable,
+      net_proceeds: args.netProceeds,
+      state: args.state,
+      data_source: args.source,
+    })
+
+    // Meta Pixel ViewContent (client-side) with eventID for dedup
+    const viewContentEventId = `vc-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    if (typeof window !== 'undefined' && (window as any).fbq) {
+      (window as any).fbq(
+        'track',
+        'ViewContent',
+        {
+          value: args.propertyValue,
+          currency: 'USD',
+          content_name: 'Reverse Mortgage Property Results',
+          content_category: 'reverse-mortgage',
+        },
+        { eventID: viewContentEventId }
+      )
+    }
+
+    // Server-side Meta CAPI (fire-and-forget)
+    fetch('/api/capi/view-content', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        eventId: viewContentEventId,
+        email: args.contact?.email,
+        phone: args.contact?.phone,
+        firstName: args.contact?.firstName,
+        lastName: args.contact?.lastName,
+        city: args.city,
+        state: args.state,
+        zipCode: args.zipCode,
+        value: args.propertyValue,
+        contentName: 'Reverse Mortgage Property Results',
+        contentCategory: 'reverse-mortgage',
+        funnelType: 'reverse-mortgage',
+        fbp: getCookie('_fbp'),
+        fbc: getCookie('_fbc'),
+        eventSourceUrl: window.location.href,
+        customData: {
+          property_value: args.propertyValue,
+          equity_available: args.equityAvailable,
+          net_proceeds: args.netProceeds,
+          mortgage_balance: args.mortgageBalance,
+          data_source: args.source,
+        },
+      }),
+    }).catch(() => {})
+
+    // LynqFlux delivery — only if we have a session
+    if (args.sessionId) {
+      fetch('/api/leads/deliver-lynqflux', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: args.sessionId,
+          propertyValue: args.propertyValue,
+          mortgageBalance: args.mortgageBalance,
+          ltvRatio: args.ltvRatio.toFixed(4),
+          userVerified: args.source === 'user_verified',
+        }),
+      })
+        .then((r) => r.json())
+        .then((r) => {
+          if (r.success) console.log('🟢 LynqFlux delivered:', r.leadId)
+          else console.warn('🔴 LynqFlux skipped/failed:', r)
+        })
+        .catch(() => {})
+    }
+  }
 
   useEffect(() => {
     initializeTracking()
@@ -93,156 +194,171 @@ export default function ReverseMortgageResultsPage() {
 
     const fetchPropertyData = async () => {
       if (typeof window === 'undefined') {
-        setIsLoading(false)
-        setLookupStatus('failed')
+        setPhase('verify')
+        setBatchData({ lookupFailed: true })
         return
       }
 
       const stored = sessionStorage.getItem(STORAGE_KEY) || localStorage.getItem(STORAGE_KEY)
       if (!stored) {
-        setIsLoading(false)
-        setLookupStatus('failed')
+        setPhase('verify')
+        setBatchData({ lookupFailed: true })
+        return
+      }
+
+      let parsedResults: StoredResults
+      try {
+        parsedResults = JSON.parse(stored) as StoredResults
+      } catch {
+        setPhase('verify')
+        setBatchData({ lookupFailed: true })
+        return
+      }
+      setResults(parsedResults)
+
+      const addressForLookup = parsedResults.addressForLookup
+      const addressInfo = parsedResults.addressInfo
+      const street = addressForLookup?.street || addressInfo?.street
+      const city = addressForLookup?.city || addressInfo?.city
+      const state = addressForLookup?.state || addressInfo?.state
+      const zipCode = addressForLookup?.zip || addressInfo?.zipCode || addressInfo?.zip
+
+      if (!street || !city || !state) {
+        console.log('No address data for property lookup → verify screen')
+        setPhase('verify')
+        setBatchData({ lookupFailed: true, state })
         return
       }
 
       try {
-        const parsedResults = JSON.parse(stored) as StoredResults
-        setResults(parsedResults)
-
-        // Get address for lookup - handle both addressForLookup and addressInfo formats
-        const addressForLookup = parsedResults.addressForLookup
-        const addressInfo = parsedResults.addressInfo
-        
-        const street = addressForLookup?.street || addressInfo?.street
-        const city = addressForLookup?.city || addressInfo?.city
-        const state = addressForLookup?.state || addressInfo?.state
-        const zipCode = addressForLookup?.zip || addressInfo?.zipCode || addressInfo?.zip
-        
-        if (!street || !city || !state) {
-          console.log('No address data for property lookup')
-          setIsLoading(false)
-          setLookupStatus('failed')
-          return
-        }
-
-        // Call BatchData API for property lookup
         console.log('🏠 Fetching property data...')
         const response = await fetch('/api/batchdata/lookup', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            address: street,
-            city: city,
-            state: state,
-            zip: zipCode,
-          }),
+          body: JSON.stringify({ address: street, city, state, zip: zipCode }),
         })
-
         const result = await response.json()
-        
+
         if (response.ok && result?.success && result?.data) {
           const propertyData = result.data as PropertyData
-          const age = parsedResults.age || 70 // Default to 70 if not set
+          const ltvRatio =
+            (result.data as any)?.ltv_ratio ??
+            (propertyData.property_value > 0
+              ? propertyData.mortgage_balance / propertyData.property_value
+              : 0)
+
+          // Gate: if BatchData LTV > 35%, send to verify screen so user can correct.
+          if (ltvRatio > MAX_QUALIFYING_LTV) {
+            console.log(`⚠️ BatchData LTV ${(ltvRatio * 100).toFixed(1)}% > 35% — routing to verify`)
+            trackGA4Event('rm_verify_shown', {
+              reason: 'ltv_above_threshold',
+              batchdata_ltv: Number(ltvRatio.toFixed(4)),
+              state,
+            })
+            setBatchData({ property: propertyData, state, lookupFailed: false })
+            setPhase('verify')
+            return
+          }
+
+          // Trusted path: BatchData LTV ≤ 35%, proceed to results + delivery.
+          const age = parsedResults.age || 70
           const calc = calculateReverseMortgage(propertyData, age)
           setCalculation(calc)
-          setLookupStatus('success')
-          
-          // Track successful lookup
-          trackGA4Event('rm_results_property_found', {
-            property_value: calc.propertyValue,
-            equity_available: calc.equityAvailable,
-            net_proceeds: calc.netProceeds,
-            state: state
+          setPhase('results')
+
+          deliverAndTrack({
+            sessionId: parsedResults.sessionId,
+            contact: parsedResults.contact,
+            propertyValue: propertyData.property_value,
+            mortgageBalance: propertyData.mortgage_balance,
+            ltvRatio,
+            city,
+            state,
+            zipCode,
+            netProceeds: calc.netProceeds,
+            equityAvailable: calc.equityAvailable,
+            source: 'batchdata',
           })
-
-          // Fire Meta CAPI ViewContent with property value for value-based optimization
-          const viewContentEventId = `vc-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-          // Also fire client-side pixel for dedup
-          if (typeof window !== 'undefined' && (window as any).fbq) {
-            (window as any).fbq('track', 'ViewContent', {
-              value: calc.propertyValue,
-              currency: 'USD',
-              content_name: 'Reverse Mortgage Property Results',
-              content_category: 'reverse-mortgage',
-            }, { eventID: viewContentEventId })
-          }
-          // Server-side CAPI (non-blocking)
-          const getCookie = (name: string) => {
-            const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'))
-            return match ? match[2] : undefined
-          }
-          fetch('/api/capi/view-content', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              eventId: viewContentEventId,
-              email: parsedResults.contact?.email,
-              phone: parsedResults.contact?.phone,
-              firstName: parsedResults.contact?.firstName,
-              lastName: parsedResults.contact?.lastName,
-              city: city,
-              state: state,
-              zipCode: zipCode,
-              value: calc.propertyValue,
-              contentName: 'Reverse Mortgage Property Results',
-              contentCategory: 'reverse-mortgage',
-              funnelType: 'reverse-mortgage',
-              fbp: getCookie('_fbp'),
-              fbc: getCookie('_fbc'),
-              eventSourceUrl: window.location.href,
-              customData: {
-                property_value: calc.propertyValue,
-                equity_available: calc.equityAvailable,
-                net_proceeds: calc.netProceeds,
-                mortgage_balance: calc.existingMortgage,
-              },
-            }),
-          }).catch(() => {}) // fire-and-forget
-
-          // Deliver lead to LynqFlux now that we have property data
-          if (parsedResults.sessionId) {
-            fetch('/api/leads/deliver-lynqflux', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                sessionId: parsedResults.sessionId,
-                propertyValue: propertyData.property_value,
-                mortgageBalance: propertyData.mortgage_balance,
-                ltvRatio: (result.data as any)?.ltv_ratio || (propertyData.mortgage_balance / propertyData.property_value).toFixed(2),
-              }),
-            }).then(r => r.json()).then(r => {
-              if (r.success) console.log('🟢 LynqFlux delivered:', r.leadId)
-              else console.warn('🔴 LynqFlux failed:', r)
-            }).catch(() => {})
-          }
 
           console.log('✅ Property data fetched successfully:', calc)
         } else {
-          console.log('❌ Property lookup failed:', result?.error || 'Unknown error')
-          setLookupStatus('failed')
-          
-          // Track failed lookup
-          trackGA4Event('rm_results_property_failed', {
-            error: result?.error || 'unknown',
-            state: state
-          })
+          console.log('❌ Property lookup failed → verify screen:', result?.error || 'Unknown error')
+          trackGA4Event('rm_results_property_failed', { error: result?.error || 'unknown', state })
+          trackGA4Event('rm_verify_shown', { reason: 'lookup_failed', state })
+          setBatchData({ lookupFailed: true, state })
+          setPhase('verify')
         }
       } catch (error) {
         console.error('Property lookup error:', error)
-        setLookupStatus('failed')
-        
-        trackGA4Event('rm_results_property_error', {
-          error: 'exception'
-        })
-      } finally {
-        setIsLoading(false)
+        trackGA4Event('rm_results_property_error', { error: 'exception' })
+        trackGA4Event('rm_verify_shown', { reason: 'lookup_exception', state })
+        setBatchData({ lookupFailed: true, state })
+        setPhase('verify')
       }
     }
 
     fetchPropertyData()
   }, [])
 
-  if (isLoading) {
+  const handleVerifyConfirm = ({
+    propertyValue,
+    mortgageBalance,
+    ltv,
+  }: {
+    propertyValue: number
+    mortgageBalance: number
+    ltv: number
+  }) => {
+    if (!results) return
+    setPhase('submitting_verify')
+
+    if (ltv > MAX_QUALIFYING_LTV) {
+      trackGA4Event('rm_disqualified', {
+        reason: 'ltv_too_high',
+        ltv: Number(ltv.toFixed(4)),
+        property_value: propertyValue,
+        mortgage_balance: mortgageBalance,
+        user_verified: true,
+      })
+      router.push('/reverse-mortgage-calculator/not-qualified?reason=ltv')
+      return
+    }
+
+    const age = results.age || 70
+    const calc = calculateReverseMortgage(
+      {
+        property_value: propertyValue,
+        mortgage_balance: mortgageBalance,
+        equity_available: Math.max(0, propertyValue - mortgageBalance),
+      },
+      age
+    )
+    setCalculation(calc)
+
+    const addressForLookup = results.addressForLookup
+    const addressInfo = results.addressInfo
+    const city = addressForLookup?.city || addressInfo?.city
+    const state = addressForLookup?.state || addressInfo?.state || batchData.state
+    const zipCode = addressForLookup?.zip || addressInfo?.zipCode || addressInfo?.zip
+
+    deliverAndTrack({
+      sessionId: results.sessionId,
+      contact: results.contact,
+      propertyValue,
+      mortgageBalance,
+      ltvRatio: ltv,
+      city,
+      state,
+      zipCode,
+      netProceeds: calc.netProceeds,
+      equityAvailable: calc.equityAvailable,
+      source: 'user_verified',
+    })
+
+    setPhase('results')
+  }
+
+  if (phase === 'loading') {
     return (
       <div className="min-h-screen bg-[#F5F5F0] flex items-center justify-center">
         <div className="text-center">
@@ -270,89 +386,24 @@ export default function ReverseMortgageResultsPage() {
     )
   }
 
-  // Generic thank you if property lookup failed
-  if (lookupStatus === 'failed') {
+  if (phase === 'verify' || phase === 'submitting_verify') {
     return (
-      <div className="min-h-screen bg-[#F5F5F0]">
-        <section className="py-10 px-4 sm:px-6 lg:px-8">
-          <div className="max-w-3xl mx-auto">
-            <div className="bg-white rounded-2xl shadow-lg border border-[#E5E7EB] p-6 sm:p-8">
-              <div className="text-center space-y-4">
-                <div className="mx-auto h-14 w-14 rounded-full bg-green-100 flex items-center justify-center">
-                  <CheckCircle className="h-8 w-8 text-green-600" />
-                </div>
-                <h1 className="text-3xl sm:text-4xl font-serif font-semibold text-[#36596A]">
-                  Thank You, {results.contact?.firstName || 'Friend'}!
-                </h1>
-                <p className="text-gray-600">
-                  Your information has been received. A licensed reverse mortgage specialist will contact you shortly to discuss your options.
-                </p>
-              </div>
-
-              {/* Agent Image Section */}
-              <div className="mt-8 bg-slate-50 rounded-2xl p-6">
-                <div className="max-w-md mx-auto text-center">
-                  <img
-                    src="/images/team/agent-advisor.png"
-                    alt="Licensed Reverse Mortgage Specialist"
-                    className="w-full max-w-sm mx-auto mb-4 object-cover rounded-lg"
-                  />
-                  <h3 className="text-xl font-semibold text-slate-800 mb-2">
-                    Your Licensed Reverse Mortgage Specialist
-                  </h3>
-                  <p className="text-slate-600 text-sm">
-                    A licensed HECM specialist will review your property details and provide personalized guidance on your reverse mortgage options.
-                  </p>
-                </div>
-              </div>
-
-              <div className="mt-8 space-y-4 text-sm text-gray-700">
-                <h2 className="text-lg font-semibold text-gray-900">What happens next</h2>
-                <div className="space-y-3">
-                  <div className="flex items-start gap-3">
-                    <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
-                    <span>
-                      <strong>Within 24 hours:</strong> A licensed reverse mortgage specialist will call you to discuss your HECM options and answer all your questions.
-                    </span>
-                  </div>
-                  <div className="flex items-start gap-3">
-                    <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
-                    <span>
-                      <strong>Custom Analysis:</strong> Your specialist will verify your property details, review FHA eligibility, and provide a personalized breakdown of available proceeds.
-                    </span>
-                  </div>
-                  <div className="flex items-start gap-3">
-                    <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
-                    <span>
-                      <strong>Your Decision:</strong> No pressure - take time to review your options and decide what's right for you.
-                    </span>
-                  </div>
-                </div>
-              </div>
-
-              <div className="mt-8 rounded-xl border border-gray-200 bg-gray-50 p-5 text-sm text-gray-700">
-                <p>
-                  Questions? Call us at{' '}
-                  <a href="tel:+18585046544" className="font-semibold text-[#36596A]">
-                    (858) 504-6544
-                  </a>
-                  .
-                </p>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <FAQ funnelType="reverse-mortgage-calculator" />
-      </div>
+      <VerifyPropertyDetails
+        initialPropertyValue={batchData.property?.property_value}
+        initialMortgageBalance={batchData.property?.mortgage_balance}
+        lookupFailed={batchData.lookupFailed}
+        onConfirm={handleVerifyConfirm}
+        isSubmitting={phase === 'submitting_verify'}
+      />
     )
   }
 
-  // Success - show equity estimate
+  // phase === 'results' — show equity estimate
   const estimatedLow = calculation ? Math.floor(calculation.netProceeds * 0.85) : 0
   const estimatedHigh = calculation?.netProceeds || 0
-  
-  // Check if mortgage exceeds available proceeds (underwater for RM purposes)
+
+  // Edge case: existing mortgage exceeds gross proceeds even though LTV ≤ 35%
+  // (rare — happens only when home value < FHA limit AND mortgage near 35% AND PLF makes gross < mortgage).
   const isUnderwaterForRM = calculation && calculation.existingMortgage > calculation.grossProceeds
 
   return (
@@ -365,21 +416,18 @@ export default function ReverseMortgageResultsPage() {
                 <CheckCircle className="h-8 w-8 text-green-600" />
               </div>
               <h1 className="text-3xl sm:text-4xl font-serif font-semibold text-[#36596A]">
-                {isUnderwaterForRM 
+                {isUnderwaterForRM
                   ? `Thank You, ${results.contact?.firstName || 'Friend'}!`
-                  : `Great News, ${results.contact?.firstName || 'Friend'}!`
-                }
+                  : `Great News, ${results.contact?.firstName || 'Friend'}!`}
               </h1>
               <p className="text-gray-600">
                 {isUnderwaterForRM
                   ? 'We found your property details. A specialist will review your options with you.'
-                  : 'Based on your property, here\'s your estimated reverse mortgage potential.'
-                }
+                  : "Based on your property, here's your estimated reverse mortgage potential."}
               </p>
             </div>
 
             {isUnderwaterForRM ? (
-              // Show explanation when mortgage exceeds available proceeds
               <div className="mt-8 rounded-xl border border-amber-500 bg-amber-50 p-6">
                 <h3 className="text-lg font-semibold text-amber-800 mb-3">
                   Your Current Mortgage May Need to Be Reduced First
@@ -392,24 +440,29 @@ export default function ReverseMortgageResultsPage() {
                     <strong>Existing Mortgage:</strong> ${calculation?.existingMortgage.toLocaleString()}
                   </p>
                   <p className="mt-3">
-                    Based on your current mortgage balance, you may need to pay down your existing loan before accessing reverse mortgage proceeds. However, there may be other options available.
+                    Based on your current mortgage balance, you may need to pay down your existing loan
+                    before accessing reverse mortgage proceeds. However, there may be other options
+                    available.
                   </p>
                   <p className="mt-2 font-medium">
-                    A licensed specialist will review your situation and discuss all available programs, including HECM for Purchase and refinancing options.
+                    A licensed specialist will review your situation and discuss all available
+                    programs, including HECM for Purchase and refinancing options.
                   </p>
                 </div>
               </div>
             ) : (
-              // Show equity estimate when proceeds are available
               <div className="mt-8 rounded-xl border border-[#36596A] bg-[#36596A] text-white p-6 text-center">
-                <p className="text-sm uppercase tracking-wide text-[#E4CDA1]">Estimated Tax-Free Equity</p>
+                <p className="text-sm uppercase tracking-wide text-[#E4CDA1]">
+                  Estimated Tax-Free Equity
+                </p>
                 <p className="mt-2 text-3xl font-bold">
                   ${estimatedLow.toLocaleString()} - ${estimatedHigh.toLocaleString()}
                 </p>
                 {calculation && (
                   <p className="mt-2 text-sm text-white/80">
                     Based on property value of ${calculation.propertyValue.toLocaleString()}
-                    {calculation.existingMortgage > 0 && ` (existing mortgage: $${calculation.existingMortgage.toLocaleString()})`}
+                    {calculation.existingMortgage > 0 &&
+                      ` (existing mortgage: $${calculation.existingMortgage.toLocaleString()})`}
                   </p>
                 )}
                 <p className="mt-2 text-sm text-white/80">
@@ -418,7 +471,6 @@ export default function ReverseMortgageResultsPage() {
               </div>
             )}
 
-            {/* Agent Image Section */}
             <div className="mt-8 bg-slate-50 rounded-2xl p-6">
               <div className="max-w-md mx-auto text-center">
                 <img
@@ -430,7 +482,8 @@ export default function ReverseMortgageResultsPage() {
                   Your Licensed Reverse Mortgage Specialist
                 </h3>
                 <p className="text-slate-600 text-sm">
-                  A licensed HECM specialist will review your property details and provide personalized guidance on your reverse mortgage options.
+                  A licensed HECM specialist will review your property details and provide
+                  personalized guidance on your reverse mortgage options.
                 </p>
               </div>
             </div>
@@ -441,19 +494,23 @@ export default function ReverseMortgageResultsPage() {
                 <div className="flex items-start gap-3">
                   <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
                   <span>
-                    <strong>Within 24 hours:</strong> A licensed reverse mortgage specialist will call you to discuss your HECM options and answer all your questions.
+                    <strong>Within 24 hours:</strong> A licensed reverse mortgage specialist will call
+                    you to discuss your HECM options and answer all your questions.
                   </span>
                 </div>
                 <div className="flex items-start gap-3">
                   <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
                   <span>
-                    <strong>Custom Analysis:</strong> Your specialist will verify your property details, review FHA eligibility, and provide a personalized breakdown of available proceeds.
+                    <strong>Custom Analysis:</strong> Your specialist will verify your property
+                    details, review FHA eligibility, and provide a personalized breakdown of available
+                    proceeds.
                   </span>
                 </div>
                 <div className="flex items-start gap-3">
                   <CheckCircle className="h-5 w-5 text-green-600 mt-0.5" />
                   <span>
-                    <strong>Your Decision:</strong> No pressure - take time to review your options and decide what's right for you.
+                    <strong>Your Decision:</strong> No pressure - take time to review your options and
+                    decide what's right for you.
                   </span>
                 </div>
               </div>

--- a/src/app/reverse-mortgage-calculator/results/page.tsx
+++ b/src/app/reverse-mortgage-calculator/results/page.tsx
@@ -281,18 +281,28 @@ export default function ReverseMortgageResultsPage() {
 
         if (response.ok && result?.success && result?.data) {
           const propertyData = result.data as PropertyData
-          const ltvRatio =
-            (result.data as any)?.ltv_ratio ??
-            (propertyData.property_value > 0
-              ? propertyData.mortgage_balance / propertyData.property_value
-              : 0)
+          // BatchData ltv_ratio is now nullable (null = truly unknown). Fall back to
+          // computed ratio when mortgage data exists; otherwise treat as null.
+          const rawLtv = (result.data as any)?.ltv_ratio
+          const ltvRatio: number | null =
+            typeof rawLtv === 'number'
+              ? rawLtv
+              : propertyData.mortgage_balance > 0 && propertyData.property_value > 0
+                ? propertyData.mortgage_balance / propertyData.property_value
+                : null
 
-          // Gate: if BatchData LTV > 35%, send to verify screen so user can correct.
-          if (ltvRatio > MAX_QUALIFYING_LTV) {
-            console.log(`⚠️ BatchData LTV ${(ltvRatio * 100).toFixed(1)}% > 35% — routing to verify`)
+          // Gate: if BatchData LTV > 35% OR LTV is unknown, send to verify screen
+          // so the user can confirm/correct. null → can't trust the gate decision.
+          if (ltvRatio === null || ltvRatio > MAX_QUALIFYING_LTV) {
+            const reason = ltvRatio === null ? 'ltv_unknown' : 'ltv_above_threshold'
+            console.log(
+              ltvRatio === null
+                ? '⚠️ BatchData LTV unknown — routing to verify'
+                : `⚠️ BatchData LTV ${(ltvRatio * 100).toFixed(1)}% > 35% — routing to verify`,
+            )
             trackGA4Event('rm_verify_shown', {
-              reason: 'ltv_above_threshold',
-              batchdata_ltv: Number(ltvRatio.toFixed(4)),
+              reason,
+              batchdata_ltv: ltvRatio !== null ? Number(ltvRatio.toFixed(4)) : undefined,
               state,
             })
             setBatchData({ property: propertyData, state, lookupFailed: false })

--- a/src/components/property/AddressAutocomplete.tsx
+++ b/src/components/property/AddressAutocomplete.tsx
@@ -35,6 +35,42 @@ export function AddressAutocomplete({
   const [address, setAddress] = useState('')
   const [isGoogleLoaded, setIsGoogleLoaded] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
+  // Manual entry fallback for when Google autocomplete fails (extensions, network,
+  // unrecognized addresses, or component binding issues).
+  const [manualMode, setManualMode] = useState(false)
+  const [manualStreet, setManualStreet] = useState('')
+  const [manualCity, setManualCity] = useState('')
+  const [manualState, setManualState] = useState('')
+  const [manualZip, setManualZip] = useState('')
+  const [manualError, setManualError] = useState('')
+
+  const submitManual = () => {
+    const street = manualStreet.trim()
+    const city = manualCity.trim()
+    const stateInput = manualState.trim().toUpperCase()
+    const zip = manualZip.trim()
+    if (!street || !city || !stateInput || !zip) {
+      setManualError('Please fill in street, city, state, and ZIP.')
+      return
+    }
+    if (!/^\d{5}(-\d{4})?$/.test(zip)) {
+      setManualError('Please enter a valid 5-digit ZIP code.')
+      return
+    }
+    if (stateInput.length !== 2) {
+      setManualError('Please use a 2-letter state code (e.g. CA, TX).')
+      return
+    }
+    setManualError('')
+    const formatted = `${street}, ${city}, ${stateInput} ${zip}`
+    onAddressSelect({
+      formatted_address: formatted,
+      street,
+      city,
+      state: stateInput,
+      zip,
+    })
+  }
 
   // Load Google Maps API
   useEffect(() => {
@@ -131,14 +167,96 @@ export function AddressAutocomplete({
     }
   }, [isGoogleLoaded, onAddressSelect])
 
+  if (manualMode) {
+    return (
+      <div className="space-y-3">
+        <div>
+          <label className="block text-sm font-semibold text-gray-700 mb-1">Street address</label>
+          <input
+            type="text"
+            value={manualStreet}
+            onChange={(e) => setManualStreet(e.target.value)}
+            placeholder="123 Main St"
+            autoComplete="street-address"
+            className="quiz-input w-full px-4 py-3 text-base border-2 border-gray-300 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all"
+          />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <div className="sm:col-span-1">
+            <label className="block text-sm font-semibold text-gray-700 mb-1">City</label>
+            <input
+              type="text"
+              value={manualCity}
+              onChange={(e) => setManualCity(e.target.value)}
+              autoComplete="address-level2"
+              className="quiz-input w-full px-4 py-3 text-base border-2 border-gray-300 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">State</label>
+            <input
+              type="text"
+              value={manualState}
+              onChange={(e) => setManualState(e.target.value.toUpperCase().slice(0, 2))}
+              placeholder="CA"
+              maxLength={2}
+              autoComplete="address-level1"
+              className="quiz-input w-full px-4 py-3 text-base border-2 border-gray-300 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all uppercase"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">ZIP</label>
+            <input
+              type="text"
+              inputMode="numeric"
+              value={manualZip}
+              onChange={(e) => setManualZip(e.target.value.replace(/[^\d-]/g, '').slice(0, 10))}
+              placeholder="92102"
+              autoComplete="postal-code"
+              className="quiz-input w-full px-4 py-3 text-base border-2 border-gray-300 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all"
+            />
+          </div>
+        </div>
+        {manualError && <p className="text-red-500 text-sm">{manualError}</p>}
+        <button
+          type="button"
+          onClick={submitManual}
+          className="w-full bg-[#36596A] text-white py-3 px-6 rounded-xl font-semibold hover:bg-[#2a4a5a] transition-colors"
+        >
+          Use this address
+        </button>
+        <div className="text-center">
+          <button
+            type="button"
+            onClick={() => { setManualMode(false); setManualError('') }}
+            className="text-sm font-medium text-gray-500 hover:underline"
+          >
+            ← Back to address search
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <input
-      ref={inputRef}
-      type="text"
-      value={address}
-      onChange={(e) => setAddress(e.target.value)}
-      placeholder={placeholder}
-      className={className}
-    />
+    <div className="space-y-2">
+      <input
+        ref={inputRef}
+        type="text"
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
+        placeholder={placeholder}
+        className={className}
+      />
+      <div className="text-center">
+        <button
+          type="button"
+          onClick={() => setManualMode(true)}
+          className="text-sm font-medium text-[#36596A] hover:underline"
+        >
+          Don't see your address? Enter manually
+        </button>
+      </div>
+    </div>
   )
 }

--- a/src/components/quiz/AddressAutocomplete.tsx
+++ b/src/components/quiz/AddressAutocomplete.tsx
@@ -45,6 +45,13 @@ export const AddressAutocomplete = ({
   const [isValid, setIsValid] = useState(false)
   const [error, setError] = useState('')
   const [addressData, setAddressData] = useState<AddressData | null>(null)
+  // Manual entry mode — for users where Google autocomplete fails (extensions blocking,
+  // poor connection, addresses Google doesn't recognize, dev environment issues).
+  const [manualMode, setManualMode] = useState(false)
+  const [manualStreet, setManualStreet] = useState('')
+  const [manualCity, setManualCity] = useState('')
+  const [manualState, setManualState] = useState('')
+  const [manualZip, setManualZip] = useState('')
 
   // Load Google Places API script
   useEffect(() => {
@@ -213,6 +220,55 @@ export const AddressAutocomplete = ({
     }
   }, [])
 
+  const handleManualSubmit = () => {
+    const street = manualStreet.trim()
+    const city = manualCity.trim()
+    const stateInput = manualState.trim().toUpperCase()
+    const zip = manualZip.trim()
+
+    if (!street || !city || !stateInput || !zip) {
+      setError('Please fill in street, city, state, and ZIP.')
+      onValidationChange?.(false)
+      return
+    }
+    if (!/^\d{5}(-\d{4})?$/.test(zip)) {
+      setError('Please enter a valid 5-digit ZIP code.')
+      onValidationChange?.(false)
+      return
+    }
+    if (stateInput.length !== 2) {
+      setError('Please use a 2-letter state code (e.g. CA, TX).')
+      onValidationChange?.(false)
+      return
+    }
+
+    // Best-effort split of "123 Main St" into streetNumber + street.
+    const streetMatch = street.match(/^(\d+\w*)\s+(.+)$/)
+    const streetNumber = streetMatch?.[1] || ''
+    const route = streetMatch?.[2] || street
+
+    const formatted = `${street}, ${city}, ${stateInput} ${zip}`
+    const address: AddressData = {
+      streetNumber,
+      street: route,
+      fullAddress: formatted,
+      city,
+      state: stateInput,
+      stateAbbr: stateInput,
+      zipCode: zip,
+      country: 'United States',
+      countryCode: 'US',
+      formatted,
+    }
+
+    setError('')
+    setAddressData(address)
+    setIsValid(true)
+    setIsValidating(false)
+    onValidationChange?.(true)
+    onChange(address)
+  }
+
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value
     setAddressValue(newValue)
@@ -230,59 +286,170 @@ export const AddressAutocomplete = ({
 
   return (
     <div className="space-y-2">
-      <div className="relative">
-        <input
-          ref={inputRef}
-          type="text"
-          value={addressValue}
-          onChange={handleInputChange}
-          className={`
-            quiz-input w-full px-6 py-4 text-lg border-2 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all
-            ${error ? 'border-red-500 bg-red-50' : isValid ? 'border-green-500 bg-green-50' : 'border-gray-300'}
-            ${disabled || isLoading ? 'opacity-50 cursor-not-allowed' : ''}
-          `}
-          placeholder="Start typing your address..."
-          required
-          disabled={disabled || isLoading}
-          style={{ minHeight: '56px' }}
-          autoComplete="street-address"
-        />
-        {isValidating && (
-          <div className="absolute right-4 top-1/2 transform -translate-y-1/2">
-            <Loader2 className="w-5 h-5 text-gray-400 animate-spin" />
-          </div>
-        )}
-        {!isValidating && isValid && addressData && (
-          <div className="absolute right-4 top-1/2 transform -translate-y-1/2">
-            <CheckCircle className="w-6 h-6 text-green-500" />
-          </div>
-        )}
-        {!isValidating && error && addressValue && (
-          <div className="absolute right-4 top-1/2 transform -translate-y-1/2">
-            <AlertTriangle className="w-5 h-5 text-red-500" />
-          </div>
-        )}
-      </div>
-
-      {error && (
-        <p className="text-red-500 text-sm mt-2">{error}</p>
-      )}
-
-      {isValid && addressData && (
-        <div className="mt-3 p-4 bg-green-50 border-2 border-green-200 rounded-xl">
-          <p className="text-green-800 text-sm font-medium">
-            ✓ Address verified: {addressData.city}, {addressData.stateAbbr} {addressData.zipCode}
-            {addressData.countryCode === 'CA' && (
-              <span className="ml-2 text-xs">({addressData.country})</span>
+      {!manualMode && (
+        <>
+          <div className="relative">
+            <input
+              ref={inputRef}
+              type="text"
+              value={addressValue}
+              onChange={handleInputChange}
+              className={`
+                quiz-input w-full px-6 py-4 text-lg border-2 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all
+                ${error ? 'border-red-500 bg-red-50' : isValid ? 'border-green-500 bg-green-50' : 'border-gray-300'}
+                ${disabled || isLoading ? 'opacity-50 cursor-not-allowed' : ''}
+              `}
+              placeholder="Start typing your address..."
+              required
+              disabled={disabled || isLoading}
+              style={{ minHeight: '56px' }}
+              autoComplete="street-address"
+            />
+            {isValidating && (
+              <div className="absolute right-4 top-1/2 transform -translate-y-1/2">
+                <Loader2 className="w-5 h-5 text-gray-400 animate-spin" />
+              </div>
             )}
-          </p>
-        </div>
+            {!isValidating && isValid && addressData && (
+              <div className="absolute right-4 top-1/2 transform -translate-y-1/2">
+                <CheckCircle className="w-6 h-6 text-green-500" />
+              </div>
+            )}
+            {!isValidating && error && addressValue && (
+              <div className="absolute right-4 top-1/2 transform -translate-y-1/2">
+                <AlertTriangle className="w-5 h-5 text-red-500" />
+              </div>
+            )}
+          </div>
+
+          {error && (
+            <p className="text-red-500 text-sm mt-2">{error}</p>
+          )}
+
+          {isValid && addressData && (
+            <div className="mt-3 p-4 bg-green-50 border-2 border-green-200 rounded-xl">
+              <p className="text-green-800 text-sm font-medium">
+                ✓ Address verified: {addressData.city}, {addressData.stateAbbr} {addressData.zipCode}
+                {addressData.countryCode === 'CA' && (
+                  <span className="ml-2 text-xs">({addressData.country})</span>
+                )}
+              </p>
+            </div>
+          )}
+
+          {addressValue && !isValid && !error && (
+            <p className="text-sm text-gray-500 mt-2">
+              Please select an address from the dropdown suggestions
+            </p>
+          )}
+
+          <div className="pt-1 text-center">
+            <button
+              type="button"
+              onClick={() => {
+                setManualMode(true)
+                setError('')
+                setIsValid(false)
+                setAddressData(null)
+                onValidationChange?.(false)
+              }}
+              className="text-sm font-medium text-[#36596A] hover:underline"
+            >
+              Don't see your address? Enter manually
+            </button>
+          </div>
+        </>
       )}
 
-      {addressValue && !isValid && !error && (
-        <p className="text-sm text-gray-500 mt-2">
-          Please select an address from the dropdown suggestions
-        </p>
+      {manualMode && (
+        <div className="space-y-3">
+          <div>
+            <label className="block text-sm font-semibold text-gray-700 mb-1">Street address</label>
+            <input
+              type="text"
+              value={manualStreet}
+              onChange={(e) => setManualStreet(e.target.value)}
+              placeholder="123 Main St"
+              autoComplete="street-address"
+              className="quiz-input w-full px-4 py-3 text-base border-2 border-gray-300 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all"
+              disabled={disabled || isLoading}
+            />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <div className="sm:col-span-1">
+              <label className="block text-sm font-semibold text-gray-700 mb-1">City</label>
+              <input
+                type="text"
+                value={manualCity}
+                onChange={(e) => setManualCity(e.target.value)}
+                autoComplete="address-level2"
+                className="quiz-input w-full px-4 py-3 text-base border-2 border-gray-300 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all"
+                disabled={disabled || isLoading}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">State</label>
+              <input
+                type="text"
+                value={manualState}
+                onChange={(e) => setManualState(e.target.value.toUpperCase().slice(0, 2))}
+                placeholder="CA"
+                maxLength={2}
+                autoComplete="address-level1"
+                className="quiz-input w-full px-4 py-3 text-base border-2 border-gray-300 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all uppercase"
+                disabled={disabled || isLoading}
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-gray-700 mb-1">ZIP</label>
+              <input
+                type="text"
+                inputMode="numeric"
+                value={manualZip}
+                onChange={(e) => setManualZip(e.target.value.replace(/[^\d-]/g, '').slice(0, 10))}
+                placeholder="92102"
+                autoComplete="postal-code"
+                className="quiz-input w-full px-4 py-3 text-base border-2 border-gray-300 rounded-xl focus:ring-4 focus:ring-[#36596A]/20 focus:border-[#36596A] transition-all"
+                disabled={disabled || isLoading}
+              />
+            </div>
+          </div>
+
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+
+          {isValid && addressData && (
+            <div className="p-4 bg-green-50 border-2 border-green-200 rounded-xl">
+              <p className="text-green-800 text-sm font-medium">
+                ✓ Address ready: {addressData.fullAddress}
+              </p>
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={handleManualSubmit}
+            disabled={disabled || isLoading}
+            className="w-full bg-[#36596A] text-white py-3 px-6 rounded-xl font-semibold hover:bg-[#2a4a5a] transition-colors disabled:opacity-50"
+          >
+            Use this address
+          </button>
+
+          <div className="text-center">
+            <button
+              type="button"
+              onClick={() => {
+                setManualMode(false)
+                setError('')
+                setIsValid(false)
+                setAddressData(null)
+                onValidationChange?.(false)
+              }}
+              className="text-sm font-medium text-gray-500 hover:underline"
+            >
+              ← Back to address search
+            </button>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/src/components/reverse-mortgage/PropertyVerificationStep.tsx
+++ b/src/components/reverse-mortgage/PropertyVerificationStep.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Loader2, Home } from 'lucide-react'
+import { VerifyPropertyDetails } from './VerifyPropertyDetails'
+
+interface PropertyData {
+  property_value: number
+  mortgage_balance: number
+  equity_available: number
+  ltv_ratio?: number
+}
+
+interface AddressInput {
+  street: string
+  city: string
+  state: string
+  zip: string
+}
+
+interface PropertyVerificationStepProps {
+  address: AddressInput
+  onConfirm: (values: {
+    propertyValue: number
+    mortgageBalance: number
+    ltv: number
+    batchDataUsed: boolean
+  }) => void
+  isSubmitting?: boolean
+  onLookupComplete?: (info: { success: boolean; ms: number; ltv?: number }) => void
+}
+
+// Hold the spinner at least this long so it feels like a real lookup, not a flash.
+const MIN_THINKING_MS = 1500
+
+export function PropertyVerificationStep({
+  address,
+  onConfirm,
+  isSubmitting,
+  onLookupComplete,
+}: PropertyVerificationStepProps) {
+  const [phase, setPhase] = useState<'thinking' | 'verify'>('thinking')
+  const [property, setProperty] = useState<PropertyData | undefined>(undefined)
+  const [lookupFailed, setLookupFailed] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    const startedAt = Date.now()
+
+    const run = async () => {
+      let next: { property?: PropertyData; lookupFailed: boolean; ltv?: number } = {
+        lookupFailed: true,
+      }
+
+      try {
+        const response = await fetch('/api/batchdata/lookup', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          // BatchData API expects { address, city, state, zip } — map from our AddressInput shape.
+          body: JSON.stringify({
+            address: address.street,
+            city: address.city,
+            state: address.state,
+            zip: address.zip,
+          }),
+        })
+        const json = await response.json()
+        if (response.ok && json?.success && json?.data) {
+          const data = json.data as PropertyData
+          const ltv =
+            typeof data.ltv_ratio === 'number'
+              ? data.ltv_ratio
+              : data.property_value > 0
+                ? data.mortgage_balance / data.property_value
+                : undefined
+          next = { property: data, lookupFailed: false, ltv }
+        }
+      } catch {
+        // keep lookupFailed=true
+      }
+
+      const elapsed = Date.now() - startedAt
+      const remaining = Math.max(0, MIN_THINKING_MS - elapsed)
+
+      timeoutId = setTimeout(() => {
+        if (cancelled) return
+        setProperty(next.property)
+        setLookupFailed(next.lookupFailed)
+        setPhase('verify')
+        onLookupComplete?.({
+          success: !next.lookupFailed,
+          ms: Date.now() - startedAt,
+          ltv: next.ltv,
+        })
+      }, remaining)
+    }
+
+    run()
+    return () => {
+      cancelled = true
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+  }, [address.street, address.city, address.state, address.zip, onLookupComplete])
+
+  if (phase === 'thinking') {
+    return (
+      <div className="py-8 text-center">
+        <div className="mx-auto h-14 w-14 rounded-full bg-[#36596A]/10 flex items-center justify-center mb-5">
+          <Home className="h-7 w-7 text-[#36596A]" />
+        </div>
+        <h2 className="text-2xl sm:text-3xl font-serif font-semibold text-[#36596A] mb-2">
+          Looking up your property…
+        </h2>
+        <p className="text-gray-600">
+          We're pulling public records on your home so you don't have to type everything in.
+        </p>
+        <div className="mt-6 flex items-center justify-center gap-2 text-[#36596A]">
+          <Loader2 className="h-5 w-5 animate-spin" />
+          <span className="text-sm">This usually takes a second or two…</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <VerifyPropertyDetails
+      chrome="embedded"
+      initialPropertyValue={property?.property_value}
+      initialMortgageBalance={property?.mortgage_balance}
+      lookupFailed={lookupFailed}
+      onConfirm={(values) =>
+        onConfirm({ ...values, batchDataUsed: !lookupFailed })
+      }
+      isSubmitting={isSubmitting}
+    />
+  )
+}

--- a/src/components/reverse-mortgage/PropertyVerificationStep.tsx
+++ b/src/components/reverse-mortgage/PropertyVerificationStep.tsx
@@ -24,6 +24,10 @@ interface PropertyVerificationStepProps {
     propertyValue: number
     mortgageBalance: number
     ltv: number
+    /** Original BatchData LTV before any user adjustment — used for defensive
+     * max(batchData, userVerified) in downstream gating (Meta CAPI, etc.).
+     * undefined when BatchData lookup failed. */
+    batchDataLtv?: number
     batchDataUsed: boolean
   }) => void
   isSubmitting?: boolean
@@ -42,6 +46,9 @@ export function PropertyVerificationStep({
   const [phase, setPhase] = useState<'thinking' | 'verify'>('thinking')
   const [property, setProperty] = useState<PropertyData | undefined>(undefined)
   const [lookupFailed, setLookupFailed] = useState(false)
+  // The original BatchData LTV (before any user adjustment) — captured here so
+  // we can pass it to onConfirm for downstream defensive gating decisions.
+  const [batchDataLtv, setBatchDataLtv] = useState<number | undefined>(undefined)
 
   useEffect(() => {
     let cancelled = false
@@ -86,6 +93,7 @@ export function PropertyVerificationStep({
       timeoutId = setTimeout(() => {
         if (cancelled) return
         setProperty(next.property)
+        setBatchDataLtv(next.ltv)
         setLookupFailed(next.lookupFailed)
         setPhase('verify')
         onLookupComplete?.({
@@ -130,7 +138,7 @@ export function PropertyVerificationStep({
       initialMortgageBalance={property?.mortgage_balance}
       lookupFailed={lookupFailed}
       onConfirm={(values) =>
-        onConfirm({ ...values, batchDataUsed: !lookupFailed })
+        onConfirm({ ...values, batchDataUsed: !lookupFailed, batchDataLtv })
       }
       isSubmitting={isSubmitting}
     />

--- a/src/components/reverse-mortgage/PropertyVerificationStep.tsx
+++ b/src/components/reverse-mortgage/PropertyVerificationStep.tsx
@@ -8,7 +8,8 @@ interface PropertyData {
   property_value: number
   mortgage_balance: number
   equity_available: number
-  ltv_ratio?: number
+  /** Decimal 0–1, or null when BatchData couldn't determine it. */
+  ltv_ratio?: number | null
 }
 
 interface AddressInput {

--- a/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
+++ b/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
@@ -1,0 +1,196 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { CheckCircle, AlertTriangle, Home } from 'lucide-react'
+
+export const MAX_QUALIFYING_LTV = 0.35
+
+interface VerifyPropertyDetailsProps {
+  initialPropertyValue?: number
+  initialMortgageBalance?: number
+  lookupFailed?: boolean
+  onConfirm: (values: { propertyValue: number; mortgageBalance: number; ltv: number }) => void
+  isSubmitting?: boolean
+}
+
+const PROPERTY_MIN = 100_000
+const PROPERTY_MAX = 2_000_000
+const PROPERTY_STEP = 5_000
+const MORTGAGE_STEP = 1_000
+
+const formatCurrency = (n: number) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(n)
+
+const parseCurrency = (raw: string) => Number(raw.replace(/[^0-9]/g, '')) || 0
+
+export function VerifyPropertyDetails({
+  initialPropertyValue,
+  initialMortgageBalance,
+  lookupFailed = false,
+  onConfirm,
+  isSubmitting = false,
+}: VerifyPropertyDetailsProps) {
+  const [propertyValue, setPropertyValue] = useState<number>(
+    Math.min(Math.max(initialPropertyValue || 400_000, PROPERTY_MIN), PROPERTY_MAX)
+  )
+  const [mortgageBalance, setMortgageBalance] = useState<number>(
+    Math.max(0, Math.min(initialMortgageBalance ?? 0, propertyValue))
+  )
+
+  const ltv = useMemo(
+    () => (propertyValue > 0 ? mortgageBalance / propertyValue : 0),
+    [propertyValue, mortgageBalance]
+  )
+  const ltvPct = Math.round(ltv * 100)
+  const qualifies = ltv <= MAX_QUALIFYING_LTV
+
+  const handlePropertyChange = (next: number) => {
+    const clamped = Math.min(Math.max(next, PROPERTY_MIN), PROPERTY_MAX)
+    setPropertyValue(clamped)
+    if (mortgageBalance > clamped) setMortgageBalance(clamped)
+  }
+
+  const handleMortgageChange = (next: number) => {
+    setMortgageBalance(Math.max(0, Math.min(next, propertyValue)))
+  }
+
+  const propertyTrackPct = ((propertyValue - PROPERTY_MIN) / (PROPERTY_MAX - PROPERTY_MIN)) * 100
+  const mortgageTrackPct = propertyValue > 0 ? (mortgageBalance / propertyValue) * 100 : 0
+
+  return (
+    <div className="min-h-screen bg-[#F5F5F0]">
+      <section className="py-10 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="bg-white rounded-2xl shadow-lg border border-[#E5E7EB] p-6 sm:p-8">
+            <div className="text-center space-y-3">
+              <div className="mx-auto h-14 w-14 rounded-full bg-[#36596A]/10 flex items-center justify-center">
+                <Home className="h-7 w-7 text-[#36596A]" />
+              </div>
+              <h1 className="text-3xl sm:text-4xl font-serif font-semibold text-[#36596A]">
+                {lookupFailed ? 'Tell us about your home' : "Let's make sure we have your numbers right"}
+              </h1>
+              <p className="text-gray-600">
+                {lookupFailed
+                  ? "We couldn't pull your property details automatically. Enter them below to see your estimate."
+                  : 'We pulled these from public records — they’re often a year or two out of date, especially if you’ve refinanced or paid down your mortgage. Please confirm or correct.'}
+              </p>
+            </div>
+
+            <div className="mt-8 space-y-8">
+              {/* Property value */}
+              <div>
+                <div className="flex items-baseline justify-between mb-2">
+                  <label className="text-sm font-semibold text-gray-700">Estimated home value</label>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={formatCurrency(propertyValue)}
+                    onChange={(e) => handlePropertyChange(parseCurrency(e.target.value))}
+                    className="w-40 text-right text-lg font-semibold text-[#36596A] border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-[#36596A]/40"
+                    aria-label="Estimated home value"
+                  />
+                </div>
+                <input
+                  type="range"
+                  min={PROPERTY_MIN}
+                  max={PROPERTY_MAX}
+                  step={PROPERTY_STEP}
+                  value={propertyValue}
+                  onChange={(e) => handlePropertyChange(Number(e.target.value))}
+                  className="w-full h-3 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                  style={{
+                    background: `linear-gradient(to right, #36596A 0%, #36596A ${propertyTrackPct}%, #e5e7eb ${propertyTrackPct}%, #e5e7eb 100%)`,
+                  }}
+                />
+                <div className="flex justify-between mt-1 text-xs text-gray-500">
+                  <span>$100K</span>
+                  <span>$2M+</span>
+                </div>
+              </div>
+
+              {/* Mortgage balance */}
+              <div>
+                <div className="flex items-baseline justify-between mb-2">
+                  <label className="text-sm font-semibold text-gray-700">
+                    Current mortgage balance{' '}
+                    <span className="font-normal text-gray-500">(enter 0 if paid off)</span>
+                  </label>
+                  <input
+                    type="text"
+                    inputMode="numeric"
+                    value={formatCurrency(mortgageBalance)}
+                    onChange={(e) => handleMortgageChange(parseCurrency(e.target.value))}
+                    className="w-40 text-right text-lg font-semibold text-[#36596A] border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-[#36596A]/40"
+                    aria-label="Current mortgage balance"
+                  />
+                </div>
+                <input
+                  type="range"
+                  min={0}
+                  max={propertyValue}
+                  step={MORTGAGE_STEP}
+                  value={mortgageBalance}
+                  onChange={(e) => handleMortgageChange(Number(e.target.value))}
+                  className="w-full h-3 bg-gray-200 rounded-lg appearance-none cursor-pointer"
+                  style={{
+                    background: `linear-gradient(to right, #36596A 0%, #36596A ${mortgageTrackPct}%, #e5e7eb ${mortgageTrackPct}%, #e5e7eb 100%)`,
+                  }}
+                />
+                <div className="flex justify-between mt-1 text-xs text-gray-500">
+                  <span>$0</span>
+                  <span>{formatCurrency(propertyValue)}</span>
+                </div>
+              </div>
+
+              {/* LTV readout + qualify indicator (no proceeds dollars by design) */}
+              <div
+                className={`rounded-xl border-2 p-5 transition-colors ${
+                  qualifies ? 'border-green-300 bg-green-50' : 'border-amber-300 bg-amber-50'
+                }`}
+                aria-live="polite"
+              >
+                <div className="flex items-center gap-3">
+                  {qualifies ? (
+                    <CheckCircle className="h-6 w-6 text-green-600 shrink-0" />
+                  ) : (
+                    <AlertTriangle className="h-6 w-6 text-amber-600 shrink-0" />
+                  )}
+                  <div className="flex-1">
+                    <p className="text-sm font-semibold text-gray-700">
+                      Your current loan-to-value:{' '}
+                      <span className={`text-base ${qualifies ? 'text-green-700' : 'text-amber-700'}`}>
+                        {ltvPct}%
+                      </span>
+                    </p>
+                    <p className={`text-sm mt-0.5 ${qualifies ? 'text-green-700' : 'text-amber-700'}`}>
+                      {qualifies
+                        ? 'Looks like a fit — a specialist can confirm your exact proceeds.'
+                        : 'Your existing mortgage is too high relative to your home value for this program.'}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <button
+              onClick={() => onConfirm({ propertyValue, mortgageBalance, ltv })}
+              disabled={isSubmitting || propertyValue <= 0}
+              className="mt-8 w-full bg-[#36596A] text-white py-3 px-6 rounded-lg font-semibold hover:bg-[#2a4a5a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Confirming...' : 'Confirm these numbers'}
+            </button>
+
+            <p className="mt-4 text-xs text-gray-500 text-center">
+              Final numbers will be confirmed by a licensed reverse mortgage specialist.
+            </p>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
+++ b/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
@@ -11,6 +11,12 @@ interface VerifyPropertyDetailsProps {
   lookupFailed?: boolean
   onConfirm: (values: { propertyValue: number; mortgageBalance: number; ltv: number }) => void
   isSubmitting?: boolean
+  /**
+   * 'page' (default): renders as a full standalone page (min-h-screen + bg + card).
+   * 'embedded': renders just the inner content, with no page background or card wrapper —
+   * for use inside an existing card (e.g. the quiz step container).
+   */
+  chrome?: 'page' | 'embedded'
 }
 
 const PROPERTY_MIN = 100_000
@@ -34,6 +40,7 @@ export function VerifyPropertyDetails({
   lookupFailed = false,
   onConfirm,
   isSubmitting = false,
+  chrome = 'page',
 }: VerifyPropertyDetailsProps) {
   const [propertyValue, setPropertyValue] = useState<number>(
     Math.min(Math.max(initialPropertyValue || 400_000, PROPERTY_MIN), PROPERTY_MAX)
@@ -62,11 +69,8 @@ export function VerifyPropertyDetails({
   const propertyTrackPct = ((propertyValue - PROPERTY_MIN) / (PROPERTY_MAX - PROPERTY_MIN)) * 100
   const mortgageTrackPct = propertyValue > 0 ? (mortgageBalance / propertyValue) * 100 : 0
 
-  return (
-    <div className="min-h-screen bg-[#F5F5F0]">
-      <section className="py-10 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-3xl mx-auto">
-          <div className="bg-white rounded-2xl shadow-lg border border-[#E5E7EB] p-6 sm:p-8">
+  const inner = (
+    <>
             <div className="text-center space-y-3">
               <div className="mx-auto h-14 w-14 rounded-full bg-[#36596A]/10 flex items-center justify-center">
                 <Home className="h-7 w-7 text-[#36596A]" />
@@ -170,7 +174,7 @@ export function VerifyPropertyDetails({
                     <p className={`text-sm mt-0.5 ${qualifies ? 'text-green-700' : 'text-amber-700'}`}>
                       {qualifies
                         ? 'Looks like a fit — a specialist can confirm your exact proceeds.'
-                        : 'Your existing mortgage is too high relative to your home value for this program.'}
+                        : 'Your equity is lower than typical for this program — a specialist will explore the right options for your situation.'}
                     </p>
                   </div>
                 </div>
@@ -188,6 +192,19 @@ export function VerifyPropertyDetails({
             <p className="mt-4 text-xs text-gray-500 text-center">
               Final numbers will be confirmed by a licensed reverse mortgage specialist.
             </p>
+    </>
+  )
+
+  if (chrome === 'embedded') {
+    return <div className="space-y-3">{inner}</div>
+  }
+
+  return (
+    <div className="min-h-screen bg-[#F5F5F0]">
+      <section className="py-10 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl mx-auto">
+          <div className="bg-white rounded-2xl shadow-lg border border-[#E5E7EB] p-6 sm:p-8">
+            {inner}
           </div>
         </div>
       </section>

--- a/src/lib/meta-capi-service.ts
+++ b/src/lib/meta-capi-service.ts
@@ -629,6 +629,12 @@ export function createCustomEvent(params: {
 export async function sendLeadEvent(params: {
   leadId: string;
   eventId?: string; // Client-generated eventID for browser+server dedup
+  /**
+   * Optional event name override. Defaults to "Lead" (standard event).
+   * Pass a custom event name (e.g. "QualifiedLead") to fire a custom CAPI event
+   * using the same user-data + custom-data pipeline.
+   */
+  eventName?: string;
   email?: string | null;
   phone?: string | null;
   firstName?: string | null;
@@ -677,13 +683,29 @@ export async function sendLeadEvent(params: {
     ...params.customData,
   };
 
-  const event = createLeadEvent({
-    leadId: params.leadId,
-    eventId: params.eventId,
-    userData,
-    customData,
-    eventSourceUrl: params.eventSourceUrl,
-  });
+  // If a custom event name is provided, build a custom CAPI event instead of Lead.
+  const event = params.eventName && params.eventName !== 'Lead'
+    ? createCustomEvent({
+        leadId: params.leadId,
+        eventName: params.eventName,
+        userData,
+        customData,
+        eventSourceUrl: params.eventSourceUrl,
+        // createCustomEvent generates its own eventId; override with caller's if present
+        ...(params.eventId ? { eventTime: Math.floor(Date.now() / 1000) } : {}),
+      })
+    : createLeadEvent({
+        leadId: params.leadId,
+        eventId: params.eventId,
+        userData,
+        customData,
+        eventSourceUrl: params.eventSourceUrl,
+      });
+
+  // For custom events, force the eventId override (so it matches the browser pixel)
+  if (params.eventName && params.eventName !== 'Lead' && params.eventId) {
+    event.event_id = params.eventId;
+  }
 
   return sendMetaCAPIEvent(event, params.options);
 }

--- a/src/lib/temp-tracking.ts
+++ b/src/lib/temp-tracking.ts
@@ -272,9 +272,20 @@ export function trackQuizComplete(
   // Only track GA4 events, Meta events handled by Lead event only
 }
 
-export function trackLeadFormSubmit(leadData: LeadData): void {
+export function trackLeadFormSubmit(
+  leadData: LeadData,
+  options: {
+    /**
+     * Set to true to suppress the (undedupable) Meta Lead pixel fire inside this
+     * helper. Use when the caller is firing its own Lead pixel event with a
+     * shared eventID for browser+server CAPI dedup — otherwise both fire and
+     * Meta double-counts (one with eventID, one without).
+     */
+    skipMetaEvent?: boolean
+  } = {}
+): void {
   console.log('📊 Tracking lead form submit:', leadData);
-  
+
   trackGA4Event('lead_form_submit', {
     session_id: leadData.sessionId,
     value: leadData.leadScore || 0,
@@ -285,13 +296,17 @@ export function trackLeadFormSubmit(leadData: LeadData): void {
     state: leadData.state,
     zip_code: leadData.zipCode
   });
-  
-  trackMetaEvent('Lead', {
-    content_name: 'SeniorSimple Retirement Lead',
-    content_category: 'lead_generation',
-    value: leadData.leadScore || 0,
-    currency: 'USD'
-  });
+
+  if (options.skipMetaEvent) {
+    console.log('📊 [trackLeadFormSubmit] Skipping Meta Lead pixel — caller fires it with eventID for CAPI dedup');
+  } else {
+    trackMetaEvent('Lead', {
+      content_name: 'SeniorSimple Retirement Lead',
+      content_category: 'lead_generation',
+      value: leadData.leadScore || 0,
+      currency: 'USD'
+    });
+  }
 
   // Track to Supabase (async, non-blocking)
   const utmParams = typeof window !== 'undefined' 

--- a/src/types/property.ts
+++ b/src/types/property.ts
@@ -14,7 +14,15 @@ export interface AddressComponents {
 export interface PropertyLookupData {
   property_value: number
   mortgage_balance: number
-  ltv_ratio: number
+  /**
+   * Loan-to-value ratio as a decimal (0–1).
+   * - null when LTV is genuinely unknown (no lien data and no BatchData valuation.ltv)
+   * - 0 when the home is paid off
+   * - >0 otherwise (preferred source: BatchData's valuation.ltv; fallback: mortgage_balance / property_value)
+   */
+  ltv_ratio: number | null
+  /** Diagnostic: where ltv_ratio came from */
+  ltv_source?: 'batchdata_valuation' | 'computed_from_lien' | 'paid_off' | 'unknown'
   address: string
   city: string
   state: string


### PR DESCRIPTION
## Overview

End-to-end rebuild of the SeniorSimple reverse-mortgage funnel to:
1. **Pre-qualify leads at 35% LTV** before contact capture, with a self-correct verify step (driven by the buyer's short-to-close DQ feedback).
2. **Soft-route high-LTV leads** to an alt thank-you (instead of hard DQ) so they can be monetized via offer wall / alt buyer.
3. **Add a dual Meta event strategy** (Lead for everyone + QualifiedLead for high-equity leads) so a future duplicate campaign can optimize on cleaner buyer-fit signal.
4. **Fix three Meta CAPI bugs** that were causing ~2.5× Lead over-reporting in production.
5. **Fix a BatchData wrapper bug** that was misclassifying paid-off homes as 70% LTV.
6. **Refactor CAPI fires into their own Vercel invocations** so they're visible to \`vercel logs -q\` searches.

## Commits (9)

| # | Commit | What |
|---|---|---|
| 1 | \`135d4e3\` | Initial 35% LTV gate + verify component (post-contact) |
| 2 | \`97667f5\` | **Move verify BEFORE contact form gate** — leads >35% never become captured leads (later softened — see #5) |
| 3 | \`1e834f8\` | \`.claude/\` dev launch config + analyst handoff doc |
| 4 | \`be83f3a\` | **Dual Meta CAPI events**: Lead (all) + QualifiedLead (LTV-gated) |
| 5 | \`f3d372c\` | **Flip QualifiedLead gate**: LTV ≤ 50% (high equity), not ≥ 50% |
| 6 | \`cc09ee2\` | **Fix BatchData wrapper**: use valuation.ltv, default to null not 0.7 |
| 7 | \`67d5ede\` | sessionStorage dedup for browser Lead pixel |
| 8 | \`24a10af\` | **Eliminate double browser Lead pixel fire** (root cause of 2.5× over-reporting) |
| 9 | \`4a67603\` | **Route CAPI fires through dedicated route** for top-level log visibility |

## Key changes

### 1. New 6-step quiz flow
homeowner → age 62+ → reason → address → **property verification (new)** → lead capture.
Step 5 runs BatchData lookup (~700ms cold) then shows a verify screen with slider+input fields for property value and mortgage balance. Live LTV % readout. Submit only enabled after verify.

### 2. Soft routing (not hard DQ)
- **LTV ≤ 35%** → \`/results\` → LynqFlux delivery (existing path, unchanged)
- **LTV > 35%** → \`/results-alt\` (new) → tagged \`ghl_status.buyer1_dq\`, **no LynqFlux call**. Placeholder for offer-wall / alt-buyer integration.

### 3. Dual Meta events
- **\`Lead\`** — fires for every submitted lead. Current campaign keeps optimizing on full volume.
- **\`QualifiedLead\`** (custom event) — fires only when \`max(BatchData LTV, user-verified LTV) ≤ 0.50\` (high equity, the leads buyer-1 actually wants). Builds the optimization signal for a duplicate Meta campaign that will be set up in Ads Manager once weekly QualifiedLead volume hits ~50.

Both events share the same pixel + CAPI infrastructure; separate eventIDs prevent dedup collision.

### 4. CAPI over-reporting fixes (3 layers)
Root cause analysis: production was reporting ~2.5× Lead conversions vs actual leads. Three independent issues:

| Issue | Fix |
|---|---|
| \`trackLeadFormSubmit\` fired an orphan Meta Lead event (no eventID, can't dedup with server CAPI) | Added \`skipMetaEvent\` option; reverse-mortgage passes it |
| Browser pixel refires on refresh / back-button / extensions | sessionStorage guard — one fire per tab |
| Server CAPI logs hidden in nested \`logs[]\` array — invisible to \`vercel logs -q\` searches | Refactor: dispatch fires to \`/api/capi/send-lead\` route so each becomes a separate Vercel invocation with top-level CAPI logs |

Expected post-deploy ratio: **1.0×**.

### 5. BatchData wrapper fix
\`/api/batchdata/lookup\` had \`ltv_ratio: ... : 0.7\` as a fallback when no mortgage balance was found. Paid-off homes (the *best* reverse-mortgage leads) were being misclassified as 70% LTV — silently excluded from the trusted LynqFlux path AND from the QualifiedLead gate even after correction (defensive max() picked the wrong 0.7).

Fixed precedence:
1. BatchData's own \`valuation.ltv\` (canonical, was previously ignored)
2. \`mortgage_balance / property_value\` when lien data exists (0 = paid off)
3. \`null\` when truly unknown — downstream routes to verify screen instead of guessing

Estimated impact: ~40% of historical leads were hitting the 0.7 default. Those flip from buyer-1 DQ to qualified.

### 6. Manual address fallback
"Don't see your address? Enter manually" link added to both AddressAutocomplete components for users where Google Maps fails (extensions, network, unknown addresses).

## Data persistence going forward

- \`leads.property_value\`, \`leads.current_mortgage\` populated on every delivery or DQ tag (was empty pre-deploy)
- \`ghl_status.lynqflux.ltv\` — effective LTV at delivery
- \`ghl_status.lynqflux.user_verified\` — true if user adjusted BatchData values
- \`ghl_status.buyer1_dq\` — { reason, ltv, property_value, mortgage_balance, batch_data_used, timestamp } on LTV >35% leads
- \`ghl_status.capi_lead_sent\` / \`capi_lead_event_id\` — already in main; preserved
- \`ghl_status.capi_qualified_lead_sent\` / \`capi_qualified_lead_event_id\` / \`capi_qualified_lead_ltv\` — new

## New files

- \`src/components/reverse-mortgage/PropertyVerificationStep.tsx\`
- \`src/components/reverse-mortgage/VerifyPropertyDetails.tsx\` (in #1)
- \`src/app/reverse-mortgage-calculator/results-alt/page.tsx\`
- \`src/app/api/leads/mark-buyer1-dq/route.ts\`
- \`.claude/handoffs/reverse-mortgage-lead-analysis.md\` — schema map + canonical queries for the next analyst agent
- \`.claude/launch.json\` — Next.js dev launch config

## Test plan

### Verify flow + routing
- [ ] Low-LTV address (e.g. \`9054 Allen Rd, Marietta OK\` returns ~33% LTV) → walk to step 5 → confirm → submit → lands on \`/results\` with LynqFlux delivery
- [ ] High-LTV address (e.g. \`1026 40th St, San Diego CA\` returns ~67% LTV) → walk to step 5 → confirm → submit → lands on \`/results-alt\`, lead row tagged \`ghl_status.buyer1_dq\`, **LynqFlux NOT called**
- [ ] Manual address entry path works for both above scenarios
- [ ] Paid-off home (mortgage balance = 0) → ltv_ratio = 0 → trusted path (was failing before the BatchData fix)

### CAPI dedup
- [ ] After deploy: \`vercel logs --environment production -q "Meta CAPI fire"\` returns Lead + QualifiedLead fire log lines at top level
- [ ] Submit one lead → Meta Events Manager shows exactly **1** Lead event (not 2)
- [ ] Submit a low-LTV lead → Meta Events Manager shows **1 Lead + 1 QualifiedLead**
- [ ] Submit a high-LTV lead → Meta Events Manager shows **1 Lead + 0 QualifiedLead** (gated out)
- [ ] Refresh \`/results\` page → no additional Lead fire (sessionStorage guard)

### Data persistence
- [ ] SQL: \`SELECT count(*) FROM leads WHERE funnel_type='reverse-mortgage' AND created_at > '2026-05-22' AND property_value IS NOT NULL\` — should match new lead count
- [ ] SQL: \`SELECT count(*) FROM leads WHERE ghl_status->'buyer1_dq' IS NOT NULL\` — confirms alt-routed leads are flowing

## Do NOT deploy to production until

1. **LynqFlux per-lead repricing conversation** — gate cuts delivered volume ~70%; per-lead price needs to rise ~3× to maintain margin. See [funnel math in the handoff doc](.claude/handoffs/reverse-mortgage-lead-analysis.md).
2. **\`/results-alt\` placeholder decision** — leave as warm thank-you, or wire up offer wall / alt mortgage buyer first?

Both are business decisions, not engineering blockers. Once aligned, this PR is ready to merge.

## Operational notes after merge

- **Watch \`ghl_status.capi_qualified_lead_sent\`** — once daily count averages ~7/day (50/week), QualifiedLead has enough volume to be used as a Meta optimization event in a new campaign. SQL in \`.claude/handoffs/reverse-mortgage-lead-analysis.md\`.
- **LynqFlux \`ltv\` wire format** — we send decimal 0–1 (e.g. \`"0.33"\`). LynqFlux has accepted this historically but their interpretation of the field is undocumented. Consider asking them to confirm format / whether they recompute from \`propertyvalue\` + \`loanamount\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)