### PR TITLE
fix: LTV is for segmentation, not delivery gating

### DIFF
--- a/src/app/api/leads/deliver-lynqflux/route.ts
+++ b/src/app/api/leads/deliver-lynqflux/route.ts
@@ -16,15 +16,12 @@ const LYNQFLUX_URL = 'https://lynqflux.com/data/244/incoming.php';
 const LYNQFLUX_PSWD = 'bXC9qjy4DEnMd4c7';
 const LYNQFLUX_LID = '244';
 
-// Buyer requires existing-mortgage LTV ≤ 35% to avoid "short to close" DNQs.
+// LTV threshold used for client-side segmentation only (route high-LTV leads
+// to /results-alt for future refi-buyer routing). NOT a server-side delivery
+// gate — every lead delivers to LynqFlux regardless of LTV so we monetize
+// the per-delivered fee on all of them. The buyer makes their own accept
+// decision at their underwriting stage.
 const MAX_QUALIFYING_LTV = 0.35;
-
-// Feature flag: when off, the LTV gate is bypassed and every lead delivers to
-// LynqFlux regardless of LTV. Default off so we can ship the BatchData fixes
-// (paid-off home recovery, verify-step failsafe) without changing the volume
-// LynqFlux currently receives. Flip to "on" via Vercel env when the per-lead
-// repricing conversation is settled.
-const LTV_GATE_ENABLED = process.env.NEXT_PUBLIC_RM_LTV_GATE === 'on';
 
 export async function OPTIONS() {
   return handleCorsOptions();
@@ -68,39 +65,10 @@ export async function POST(request: NextRequest) {
       return createCorsResponse({ success: true, message: 'Already delivered', leadId: lead.id });
     }
 
-    // Hard gate: LTV must be ≤ 35% to avoid buyer "short to close" DNQs.
-    // Gated behind LTV_GATE_ENABLED env flag — when off (default), every lead
-    // delivers regardless of LTV. Flip NEXT_PUBLIC_RM_LTV_GATE=on to activate.
-    if (LTV_GATE_ENABLED && effectiveLtv > MAX_QUALIFYING_LTV) {
-      console.log(
-        `🛑 LYNQFLUX SKIPPED — lead=${lead.id} ltv=${(effectiveLtv * 100).toFixed(1)}% exceeds ${MAX_QUALIFYING_LTV * 100}% cap`,
-      );
-      const existingGhlStatus = lead.ghl_status || {};
-      await callreadyQuizDb
-        .from('leads')
-        .update({
-          property_value: pvNum || null,
-          current_mortgage: mbNum || null,
-          ghl_status: {
-            ...existingGhlStatus,
-            lynqflux: {
-              skipped: true,
-              reason: 'ltv_above_35',
-              ltv: Number(effectiveLtv.toFixed(4)),
-              user_verified: !!userVerified,
-              timestamp: new Date().toISOString(),
-            },
-          },
-        })
-        .eq('id', lead.id);
-      return createCorsResponse({
-        success: false,
-        skipped: true,
-        reason: 'ltv_above_35',
-        ltv: Number(effectiveLtv.toFixed(4)),
-        leadId: lead.id,
-      });
-    }
+    // Note: no server-side LTV gate. Every lead delivers to LynqFlux regardless
+    // of LTV. The client-side router separately sends high-LTV leads to
+    // /results-alt for segmentation and buyer1_dq tagging, but the LynqFlux
+    // delivery happens for both /results and /results-alt paths.
 
     // Contact data is JSONB
     const contact = lead.contact || {};

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -780,13 +780,11 @@ export default function ReverseMortgageCalculatorPage() {
         address: address.formatted_address
       })
 
-      // Route based on buyer-1 fit. >35% LTV leads land on /results-alt so we can
-      // segment them downstream for offer-wall / alt-buyer routing.
-      // Gated behind NEXT_PUBLIC_RM_LTV_GATE — when off (default), every lead
-      // routes to /results regardless of LTV (preserves current LynqFlux volume).
-      const LTV_GATE_ENABLED = process.env.NEXT_PUBLIC_RM_LTV_GATE === 'on'
-      const isBuyer1Fit = !LTV_GATE_ENABLED
-        || (!!verifiedProperty && verifiedProperty.ltv <= MAX_QUALIFYING_LTV)
+      // Route based on buyer-1 fit. >35% LTV leads land on /results-alt so we
+      // can segment them downstream for refi-buyer / offer-wall routing. BOTH
+      // pages deliver to LynqFlux — segmentation is just routing + tagging,
+      // not a delivery gate. Every lead earns the per-delivered fee.
+      const isBuyer1Fit = !!verifiedProperty && verifiedProperty.ltv <= MAX_QUALIFYING_LTV
       router.push(
         isBuyer1Fit
           ? '/reverse-mortgage-calculator/results'

--- a/src/app/reverse-mortgage-calculator/results-alt/page.tsx
+++ b/src/app/reverse-mortgage-calculator/results-alt/page.tsx
@@ -8,17 +8,18 @@ import { initializeTracking, trackPageView, trackGA4Event } from '@/lib/temp-tra
 import { FAQ } from '@/components/quiz/FAQ'
 
 /**
- * Alt thank-you for reverse-mortgage leads that don't fit Buyer 1 (LTV > 35%).
+ * Alt thank-you for reverse-mortgage leads with LTV > 35%.
  *
- * The lead is captured in the DB but never sent to LynqFlux. This page:
- *   1. Tags the lead with ghl_status.buyer1_dq so we can segment downstream
- *   2. Shows a warm, neutral thank-you (no specific equity promise)
- *   3. Acts as the future surface for an offer wall / alt-buyer routing
+ * Behavior:
+ *   1. Delivers the lead to LynqFlux (same as /results — we monetize every lead
+ *      via the per-delivered fee, regardless of LTV).
+ *   2. Tags the lead with ghl_status.buyer1_dq so we can segment downstream
+ *      (e.g. when we sign a refi buyer, this is the cohort to route to them).
+ *   3. Shows a warm, neutral thank-you (no specific equity promise).
  *
- * Future enhancements (not yet wired):
- *   - Affiliate offer wall (debt consolidation, refi, HELOC, credit repair)
- *   - Direct route to a secondary mortgage buyer that accepts higher LTV
- *   - Email nurture sequence with content tailored to high-LTV homeowners
+ * The /results-alt vs /results split is for SEGMENTATION + UX, not delivery
+ * gating. Both pages deliver to LynqFlux. Future refi-buyer / offer-wall
+ * routing slots into this page.
  */
 
 const STORAGE_KEY = 'reverse_mortgage_calculator'
@@ -74,6 +75,35 @@ export default function ReverseMortgageResultsAltPage() {
 
     const vp = parsed.verifiedProperty
     if (parsed.sessionId && vp) {
+      // 1) Deliver to LynqFlux — same as /results. We monetize every lead.
+      //    LynqFlux makes its own accept/reject decision at their stage.
+      fetch('/api/leads/deliver-lynqflux', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sessionId: parsed.sessionId,
+          propertyValue: vp.propertyValue,
+          mortgageBalance: vp.mortgageBalance,
+          ltvRatio: vp.ltv,
+          userVerified: !vp.batchDataUsed,
+        }),
+      })
+        .then((r) => r.json())
+        .then((r) => {
+          if (r.success) {
+            console.log('🟢 LynqFlux delivered (alt path):', r.leadId)
+          } else {
+            console.warn('🔴 LynqFlux delivery (alt path) failed:', r)
+          }
+        })
+        .catch((err) => {
+          console.error('LynqFlux delivery (alt path) error:', err)
+        })
+
+      // 2) Tag the lead as buyer1_dq for segmentation. This is independent of
+      //    the LynqFlux delivery — both writes merge into ghl_status. Used by
+      //    downstream queries to identify the high-LTV cohort for routing to
+      //    a refi buyer / offer wall when that's wired up.
       fetch('/api/leads/mark-buyer1-dq', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -88,7 +118,7 @@ export default function ReverseMortgageResultsAltPage() {
         .then((r) => r.json())
         .then((r) => {
           if (r.success) {
-            console.log('🟠 Buyer-1 DQ recorded for lead', r.leadId)
+            console.log('🟠 Buyer-1 DQ tag recorded for lead', r.leadId)
             setTagged('done')
           } else {
             console.warn('🔴 Buyer-1 DQ tag failed:', r)


### PR DESCRIPTION
## Why
The 35% LTV check was implemented as a delivery gate (could skip LynqFlux entirely). That's not what was committed to — the original plan was a manual-entry failsafe + routing for segmentation. Every lead should still deliver so we monetize the per-delivered fee.

## What changes
- **deliver-lynqflux**: removed LTV gate block. Always delivers.
- **page.tsx**: removed env flag from client routing. /results vs /results-alt is now purely \`ltv > 0.35\`, always on.
- **/results-alt**: now also fires deliver-lynqflux alongside mark-buyer1-dq.

## Behavior after merge
| LTV | Routes to | Delivers to LynqFlux? | Tagged buyer1_dq? |
|---|---|---|---|
| ≤ 35% | /results | ✅ Yes | No |
| > 35% | /results-alt | ✅ Yes (also) | ✅ Yes (for future refi-buyer routing) |

## Cleanup
\`NEXT_PUBLIC_RM_LTV_GATE\` env var is now unused — safe to remove from Vercel after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)