### PR TITLE
fix: gate Meta Lead event to LTV ≤50%, drop QualifiedLead

### DIFF
--- a/src/app/api/leads/submit-without-otp/route.ts
+++ b/src/app/api/leads/submit-without-otp/route.ts
@@ -766,6 +766,18 @@ export async function POST(request: NextRequest) {
     // DEDUP: Only send CAPI Lead once per lead — skip if already sent
     const existingGhlStatus = lead.ghl_status || {};
     const capiAlreadySent = existingGhlStatus?.capi_lead_sent;
+
+    // LTV gate for reverse-mortgage: the client only sets body.capiEventId when
+    // the lead is buyer-1 quality (LTV ≤ 0.50 / equity ≥ 50%). If the eventId
+    // is missing for a reverse-mortgage submission, the client gated the fire
+    // and we must not send CAPI for this lead either.
+    //
+    // Why this matters: we'd rather under-report in Meta and have the campaign
+    // optimize on high-intent leads than over-report and dilute the signal
+    // while waiting for a second buyer order. Server-side LTV is also
+    // re-validated below as a defensive check.
+    const reverseMortgageLeadGated = isReverseMortgage && !body.capiEventId;
+
     // Verbose entry logging: production currently shows 0 Lead CAPI fires for
     // dozens of submits with no skip/sent/error logs. These breadcrumbs help
     // identify where the silent skip is happening.
@@ -774,18 +786,50 @@ export async function POST(request: NextRequest) {
       funnelType,
       capiAlreadySent: !!capiAlreadySent,
       capiEventIdReceived: !!body.capiEventId,
+      reverseMortgageLeadGated,
+      leadGate: body.leadGate || null,
       hasMetaCookies: !!body.metaCookies,
       ghlStatusKeys: Object.keys(existingGhlStatus),
     });
     if (capiAlreadySent) {
       console.log(`[Meta CAPI] ⏭️ Skipping Lead event — already sent at ${capiAlreadySent} for lead=${lead.id}`);
     }
+    if (reverseMortgageLeadGated) {
+      console.log(`[Meta CAPI] ⏭️ Skipping Lead event — reverse-mortgage LTV gate (>0.50, equity <50%) for lead=${lead.id}`, {
+        leadGate: body.leadGate || null,
+      });
+    }
 
-    // Lead event fires for EVERY submitted lead (current campaign keeps full
-    // optimization volume). The QualifiedLead custom event is a separate fire
-    // gated on LTV ≤ 0.50 — see below, after the Lead event block.
+    // Defensive server-side LTV gate (reverse-mortgage only). The client only
+    // sends capiEventId when its gate passes, but we re-check using the stored
+    // verifiedProperty in case the client payload was tampered with or stale.
+    let reverseMortgageServerGated = false;
+    if (isReverseMortgage && body.capiEventId) {
+      const vp = quizAnswers?.verifiedProperty || {};
+      const gatingLtv = Math.max(Number(vp.ltv) || 0, Number(vp.batchDataLtv) || 0);
+      const LEAD_CEILING = 0.50;
+      const serverShouldFire = gatingLtv > 0 && gatingLtv <= LEAD_CEILING;
+      if (!serverShouldFire) {
+        reverseMortgageServerGated = true;
+        console.log('[Meta CAPI] ⏭️ Skipping Lead event — server LTV re-check failed', {
+          leadId: lead.id,
+          gatingLtv,
+          ceiling: LEAD_CEILING,
+        });
+      }
+    }
 
-    if (!capiAlreadySent) try {
+    // Lead event fires for:
+    //   - Non-reverse-mortgage funnels: every submitted lead (unchanged)
+    //   - Reverse-mortgage: ONLY when LTV ≤ 0.50 (equity ≥ 50%) — i.e. buyer-1
+    //     quality. Higher-LTV leads still deliver to LynqFlux but do NOT
+    //     report a Lead conversion to Meta. This is the Option-A pivot: we
+    //     fold the QualifiedLead signal into the main Lead event so Meta's
+    //     existing campaign starts optimizing on high-intent leads
+    //     immediately, instead of waiting for a separate event to accumulate
+    //     ~50 conversions/week of stable signal.
+
+    if (!capiAlreadySent && !reverseMortgageLeadGated && !reverseMortgageServerGated) try {
       // ──────────────────────────────────────────────────────────────────────
       // For reverse-mortgage, fire CAPI via a dedicated route (/api/capi/send-lead)
       // so the CAPI logs land in their own Vercel invocation. That makes
@@ -799,7 +843,9 @@ export async function POST(request: NextRequest) {
         : (coverageAmount || 0);
 
       const sharedCustomData = {
-        content_name: isReverseMortgage ? 'Reverse Mortgage Lead' : `${funnelType} Lead`,
+        content_name: isReverseMortgage
+          ? 'Reverse Mortgage Lead (LTV≤50% / equity≥50%)'
+          : `${funnelType} Lead`,
         coverage_amount: coverageAmount,
         retirement_savings: retirementSavings,
         allocation_percent: allocationPercent,
@@ -909,83 +955,11 @@ export async function POST(request: NextRequest) {
       // Don't fail the request - CAPI is non-critical
     }
 
-    // ────────────────────────────────────────────────────────────────────────
-    // QualifiedLead custom event (separate from Lead) — fires only when LTV ≤ 50%
-    // (≥50% equity — the leads buyer-1 actually wants). Builds the optimization
-    // signal for a duplicated Meta campaign that will optimize on higher-intent
-    // leads once it has stable volume (~50 events/week).
-    // ────────────────────────────────────────────────────────────────────────
-    if (isReverseMortgage && body.qualifiedLeadEventId) {
-      const vp = quizAnswers?.verifiedProperty || {};
-      const gatingLtv = Math.max(Number(vp.ltv) || 0, Number(vp.batchDataLtv) || 0);
-      const QUALIFIED_CEILING = 0.50;
-
-      // Defensive: re-check the gate server-side. Browser only sets eventId when
-      // gate passes, but server validates the actual stored LTV.
-      const serverShouldFire = gatingLtv > 0 && gatingLtv <= QUALIFIED_CEILING;
-      const alreadySent = existingGhlStatus?.capi_qualified_lead_sent;
-
-      console.log('[Meta CAPI] QualifiedLead gate (server)', {
-        leadId: lead.id,
-        gatingLtv,
-        ceiling: QUALIFIED_CEILING,
-        clientSentEventId: !!body.qualifiedLeadEventId,
-        serverShouldFire,
-        alreadySent: !!alreadySent,
-      });
-
-      if (serverShouldFire && !alreadySent) {
-        // Dispatch QualifiedLead to /api/capi/send-lead so the CAPI logs land
-        // in a dedicated Vercel invocation (top-level visible to vercel logs -q).
-        const origin = new URL(request.url).origin;
-        console.log('[Meta CAPI] 🔵 Dispatching QualifiedLead fire to /api/capi/send-lead', {
-          leadId: lead.id,
-          eventId: body.qualifiedLeadEventId,
-          gatingLtv,
-        });
-        try {
-          const qResp = await fetch(`${origin}/api/capi/send-lead`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              leadId: lead.id,
-              eventId: body.qualifiedLeadEventId,
-              eventName: 'QualifiedLead',
-              value: 0,
-              customData: {
-                content_name: 'Reverse Mortgage Qualified Lead (LTV≤50% / equity≥50%)',
-                property_value: vp.propertyValue || undefined,
-                mortgage_balance: vp.mortgageBalance || undefined,
-                ltv: gatingLtv,
-                ltv_source: vp.batchDataUsed ? 'batchdata' : 'user_verified',
-                ltv_ceiling: QUALIFIED_CEILING,
-              },
-              userOverrides: {
-                email,
-                phone: phoneNumber,
-                firstName,
-                lastName,
-                fbp: body.metaCookies?.fbp,
-                fbc: body.metaCookies?.fbc,
-                fbLoginId: body.metaCookies?.fbLoginId,
-                city: city || quizAnswers?.city || '',
-                state: state || addressState || '',
-                zipCode: zipCode || addressZip || '',
-              },
-            }),
-          });
-          const qJson = await qResp.json().catch(() => ({}));
-          console.log('[Meta CAPI] 🔵 QualifiedLead fire dispatch result', {
-            leadId: lead.id,
-            status: qResp.status,
-            success: qJson?.success,
-            skipped: qJson?.skipped,
-          });
-        } catch (qDispatchErr) {
-          console.error('[Meta CAPI] QualifiedLead dispatch error:', qDispatchErr);
-        }
-      }
-    }
+    // QualifiedLead custom event was REMOVED in the Option-A pivot.
+    // We fold the high-intent signal directly into the Lead event by gating
+    // it to LTV ≤ 0.50 above. Rationale: Meta's existing campaign already
+    // optimizes on Lead — we under-report rather than spin up a parallel
+    // custom event that would take weeks to accumulate stable volume.
 
     // Send to GHL webhook with timeout
     const webhookRequestLabel = '🚀 Making GHL webhook request...';

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -559,23 +559,20 @@ export default function ReverseMortgageCalculatorPage() {
     const metaCookies = getMetaCookies()
     const fbLoginId = typeof window !== 'undefined' && (window as any).FB?.getAuthResponse?.()?.userID || null
 
-    // Generate shared eventID for browser pixel + server CAPI deduplication
-    const capiEventId = `lead-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
-
-    // Decide whether to also fire the QualifiedLead custom event.
-    // Low LTV = high equity = lead the buyer actually wants. Gate fires when LTV
-    // is at or below the ceiling (≤ 0.50 = ≥50% equity).
-    // Defensive: take max(BatchData, user-verified) so users adjusting numbers
-    // downward at step 5 can't game their way into the qualified bucket.
-    // Generated upfront so browser pixel and server CAPI use the same eventID for dedup.
-    const QUALIFIED_LEAD_LTV_CEILING = 0.50
+    // Meta Lead event gating — fires only when max(BatchData, user-verified) LTV
+    // is ≤ 0.50 (≥50% equity). Intentional underreporting: train Meta to optimize
+    // toward the cohort that actually converts with the buyer (low-LTV / high-
+    // equity homeowners) instead of every form submit.
+    // Defensive max() catches users who adjust numbers downward at step 5.
+    const LEAD_LTV_CEILING = 0.50
     const gatingLtv = Math.max(
       verifiedProperty?.ltv ?? 0,
       verifiedProperty?.batchDataLtv ?? 0,
     )
-    const fireQualifiedLead = gatingLtv > 0 && gatingLtv <= QUALIFIED_LEAD_LTV_CEILING
-    const qualifiedLeadEventId = fireQualifiedLead
-      ? `qlead-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    const fireLead = gatingLtv > 0 && gatingLtv <= LEAD_LTV_CEILING
+    // Generated upfront so browser pixel and server CAPI share the same eventID.
+    const capiEventId = fireLead
+      ? `lead-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
       : undefined
 
     const payload = {
@@ -598,18 +595,13 @@ export default function ReverseMortgageCalculatorPage() {
         fbc: metaCookies.fbc,
         fbLoginId: fbLoginId,
       },
-      // Shared eventID for browser+server CAPI dedup (Lead event — fires for everyone)
+      // Shared eventID for browser+server CAPI dedup. When undefined (LTV > 0.50),
+      // server skips the CAPI Lead event entirely — Lead is gated to ≤ 50% LTV.
       capiEventId,
-      // QualifiedLead custom event — only when LTV >= 0.50 (≥50% LTV). When this
-      // eventId is set, the server fires a matching CAPI QualifiedLead event with
-      // it for browser/server dedup. When undefined, the server skips the event.
-      // This is the dual-event setup: Lead optimizes the current campaign, while
-      // QualifiedLead builds the optimization signal for a future duplicate campaign.
-      qualifiedLeadEventId,
-      qualifiedLeadGate: {
+      leadGate: {
         gatingLtv: Number(gatingLtv.toFixed(4)),
-        ceiling: QUALIFIED_LEAD_LTV_CEILING,
-        shouldFire: fireQualifiedLead,
+        ceiling: LEAD_LTV_CEILING,
+        shouldFire: fireLead,
         ltvSource: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
       },
     }
@@ -708,70 +700,43 @@ export default function ReverseMortgageCalculatorPage() {
       })
       
       // ────────────────────────────────────────────────────────────────────────
-      // Meta dual-event strategy
+      // Meta Lead event — gated to LTV ≤ 50%
       // ────────────────────────────────────────────────────────────────────────
-      // 1) `Lead` — fires for EVERY submitted lead (unchanged behavior). Current
-      //    campaign keeps optimizing on full volume; do not break it.
-      // 2) `QualifiedLead` — custom event, fires only when LTV ≤ 50% (i.e.
-      //    ≥50% equity, the leads the buyer actually wants). Builds the
-      //    optimization signal for a duplicated Meta campaign that will
-      //    optimize on higher-intent leads once it accumulates ~50 events/week.
-      // Both events use the same pixel + CAPI. The gate decision and event IDs
-      // were generated upfront (before fetch) so server CAPI can dedup against
-      // these browser pixel events.
-      // sessionStorage dedup: each Meta event fires at most once per browser tab.
-      // Eliminates the 2.5× over-reporting observed when users refresh / back-button
-      // / resubmit and the browser pixel fires again with a fresh eventID (server
-      // CAPI dedup can't help when each fire uses a different eventID).
+      // Intentional underreporting: train Meta to optimize toward the cohort
+      // that actually converts with the buyer (low-LTV / high-equity homeowners)
+      // instead of every form submit. Below Meta's ~50 events/week optimization
+      // threshold at current volume — accept that trade-off in exchange for a
+      // cleaner training signal when ads resume.
+      // sessionStorage guard prevents refires within the same browser tab
+      // (refresh / back-button / extension retries).
       const LEAD_FIRED_KEY = 'rm_meta_lead_fired'
-      const QUAL_FIRED_KEY = 'rm_meta_qualified_lead_fired'
       const leadAlreadyFired = typeof window !== 'undefined'
         && sessionStorage.getItem(LEAD_FIRED_KEY) === '1'
-      const qualAlreadyFired = typeof window !== 'undefined'
-        && sessionStorage.getItem(QUAL_FIRED_KEY) === '1'
 
-      console.log('[Meta CAPI] Dual-event firing', {
-        leadEventId: capiEventId,
-        qualifiedLeadEventId,
+      console.log('[Meta CAPI] Lead event gate', {
         gatingLtv,
-        fireQualifiedLead,
+        ceiling: LEAD_LTV_CEILING,
+        fireLead,
+        leadEventId: capiEventId,
         leadAlreadyFired,
-        qualAlreadyFired,
       })
 
-      // Lead event (fires for everyone — current campaign signal). sessionStorage
-      // guard prevents refires within the same browser tab.
-      if (!leadAlreadyFired) {
+      if (fireLead && capiEventId && !leadAlreadyFired) {
         trackMetaPixelEvent('Lead', {
-          content_name: 'Reverse Mortgage Lead',
-          content_category: 'reverse-mortgage',
-          value: 0,
-          currency: 'USD',
-          ltv: gatingLtv > 0 ? Number(gatingLtv.toFixed(4)) : undefined,
-          ltv_source: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
-        }, 'reverse-mortgage', capiEventId)
-        if (typeof window !== 'undefined') {
-          sessionStorage.setItem(LEAD_FIRED_KEY, '1')
-        }
-      } else {
-        console.log('[Meta CAPI] ⏭️ Skipping browser Lead pixel — already fired this session')
-      }
-
-      // QualifiedLead custom event (only LTV ≤ 50% — high-equity, future campaign signal)
-      if (fireQualifiedLead && qualifiedLeadEventId && !qualAlreadyFired
-          && typeof window !== 'undefined' && (window as any).fbq) {
-        (window as any).fbq('trackCustom', 'QualifiedLead', {
-          content_name: 'Reverse Mortgage Qualified Lead (LTV≤50% / equity≥50%)',
+          content_name: 'Reverse Mortgage Lead (LTV≤50%)',
           content_category: 'reverse-mortgage',
           value: 0,
           currency: 'USD',
           ltv: Number(gatingLtv.toFixed(4)),
           ltv_source: verifiedProperty?.batchDataUsed ? 'batchdata' : 'user_verified',
-          funnel_type: 'reverse-mortgage',
-        }, { eventID: qualifiedLeadEventId })
-        sessionStorage.setItem(QUAL_FIRED_KEY, '1')
-      } else if (fireQualifiedLead && qualAlreadyFired) {
-        console.log('[Meta CAPI] ⏭️ Skipping browser QualifiedLead pixel — already fired this session')
+        }, 'reverse-mortgage', capiEventId)
+        if (typeof window !== 'undefined') {
+          sessionStorage.setItem(LEAD_FIRED_KEY, '1')
+        }
+      } else if (fireLead && leadAlreadyFired) {
+        console.log('[Meta CAPI] ⏭️ Skipping browser Lead pixel — already fired this session')
+      } else if (!fireLead) {
+        console.log(`[Meta CAPI] ⏭️ Skipping browser Lead pixel — LTV ${(gatingLtv * 100).toFixed(1)}% > ${LEAD_LTV_CEILING * 100}% ceiling`)
       }
       
       console.log('📊 Lead Submitted Successfully:', {


### PR DESCRIPTION
## Summary
- **Option A pivot**: instead of firing two Meta events (Lead always + QualifiedLead at LTV≤50%), fire a single Lead event already gated to the buyer-1 quality cohort (LTV ≤ 50% / equity ≥ 50%).
- **Why**: buyer is delivering 50 more leads contingent on Meta optimizing on high-intent signal. Folding the gate into Lead means the existing campaign starts learning on the right cohort immediately, instead of waiting weeks for QualifiedLead to accumulate ~50/wk of stable volume.
- We intentionally under-report in Meta (only ~half of submitted leads count as Lead conversions). The alternative was diluting the optimization signal with high-LTV leads that don't convert downstream.
- **LynqFlux delivery is unchanged** — every lead still ships to the buyer regardless of LTV. Segmentation to `/results-alt` remains for future refi-buyer routing only.

## Changes
**Client** (`src/app/reverse-mortgage-calculator/page.tsx`):
- Rename `QUALIFIED_LEAD_LTV_CEILING` → `LEAD_LTV_CEILING` (0.50)
- Single `fireLead` computation; `capiEventId` only set when gate passes
- Browser pixel: single gated Lead fire with `ltv` and `ltv_source` in custom_data
- Removed QualifiedLead `trackCustom` block and `qualifiedLeadEventId` payload field

**Server** (`src/app/api/leads/submit-without-otp/route.ts`):
- Gate Lead CAPI dispatch on `body.capiEventId` (client gate) **plus** a server-side LTV re-check (defensive: re-validates stored `verifiedProperty.ltv`)
- Removed QualifiedLead dispatch block entirely
- Updated content_name to `Reverse Mortgage Lead (LTV≤50% / equity≥50%)`

## Test plan
- [ ] Submit a reverse-mortgage lead with LTV ≤ 50% → Meta Test Events shows one Lead with matching eventID (browser + CAPI dedup)
- [ ] Submit a reverse-mortgage lead with LTV > 50% → Meta Test Events shows zero Lead events
- [ ] Both LTV cohorts: confirm LynqFlux delivery still happens (check `ghl_status.lynqflux.success` in Supabase)
- [ ] High-LTV cohort: confirm `/results-alt` page renders and `ghl_status.buyer1_dq` tag is set
- [ ] Annuity / non-reverse-mortgage submissions: confirm Lead event still fires every time (unchanged path)
- [ ] Check Vercel logs for `[Meta CAPI] ⏭️ Skipping Lead event — reverse-mortgage LTV gate` on a high-LTV submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)