### PR TITLE
fix: preserve ghl_status fields across post-CAPI updates

### DIFF
--- a/src/app/api/leads/submit-without-otp/route.ts
+++ b/src/app/api/leads/submit-without-otp/route.ts
@@ -1056,7 +1056,14 @@ export async function POST(request: NextRequest) {
       console.log('✅ Lead Sent to GHL Successfully:', { leadId: lead.id, status: ghlResponse.status, trustedFormCertUrl: savedTrustedFormCertUrl || 'NOT PROVIDED' });
       
       // Update lead with GHL status (merge with existing to preserve capi_lead_sent, lynqflux, etc.)
-      const currentGhlStatus = lead.ghl_status || {};
+      // Re-fetch ghl_status — the inline CAPI dispatch above wrote capi_lead_sent
+      // after `lead` was loaded, so spreading the original snapshot would wipe it.
+      const { data: freshLead } = await callreadyQuizDb
+        .from('leads')
+        .select('ghl_status')
+        .eq('id', lead.id)
+        .maybeSingle();
+      const currentGhlStatus = freshLead?.ghl_status || lead.ghl_status || {};
       await callreadyQuizDb
         .from('leads')
         .update({
@@ -1110,7 +1117,13 @@ export async function POST(request: NextRequest) {
       });
 
       // Update lead with failed GHL status (merge with existing to preserve capi_lead_sent, lynqflux, etc.)
-      const currentGhlStatusFail = lead.ghl_status || {};
+      // Re-fetch ghl_status — see comment on the success branch above.
+      const { data: freshLeadFail } = await callreadyQuizDb
+        .from('leads')
+        .select('ghl_status')
+        .eq('id', lead.id)
+        .maybeSingle();
+      const currentGhlStatusFail = freshLeadFail?.ghl_status || lead.ghl_status || {};
       await callreadyQuizDb
         .from('leads')
         .update({


### PR DESCRIPTION
## Summary
- `submit-without-otp` was loading `lead.ghl_status` once at handler start, then writing `capi_lead_sent` + `capi_lead_event_id` inline via the CAPI dispatch, then running a downstream GHL response update that spread the **original** in-memory snapshot — silently wiping the freshly-written CAPI stamp.
- Re-fetch `ghl_status` from the row immediately before each of the two GHL merges (success branch + failure branch) so the stamp survives.
- Costs one extra SELECT per submission; eliminates the read-modify-write race documented in the 2026-05-22 postmortem (Failure #4).

## Confirmed in production (pre-fix)
Smoke test on 2026-05-28 (lead `7667066e-8ce5-410d-862f-bcc9827e2973`): Vercel logs showed CAPI Lead fired successfully, but DB row's `ghl_status.capi_lead_sent` was `null`. Made "did CAPI fire for lead X?" un-answerable from the DB.

## Why option 1 (re-fetch) over option 2 (DB-level JSONB merge)
Option 2 (Postgres RPC / `jsonb_set`) is race-proof but requires more surgery. Re-fetch costs one extra SELECT per submission and is bulletproof against the in-handler ordering. No other writer touches the row between CAPI stamp and GHL merge in this handler.

## Other routes audited
- `src/app/api/leads/deliver-lynqflux/route.ts` — already fine; standalone POST handler with one read + one write, no intervening write.
- `src/app/api/capi/send-lead/route.ts` — does not write `ghl_status` itself; the stamp writer is actually inline in `submit-without-otp`. No fix needed here.

## Test plan
- [ ] Deploy to prod
- [ ] POST a synthetic low-LTV lead to `/api/leads/submit-without-otp` (`funnelType: reverse-mortgage-calculator`, `capiEventId`, `quizAnswers.verifiedProperty.ltv = 0.30`, `@seniorsimple-smoke.test` email)
- [ ] Query Supabase: `SELECT ghl_status FROM leads WHERE id = <new lead id>`
- [ ] Confirm `ghl_status.capi_lead_sent` is a timestamp AND `ghl_status.status` is 200 (both present, neither wiped)
- [ ] Delete the synthetic lead + contact when done

🤖 Generated with [Claude Code](https://claude.com/claude-code)