### PR TITLE
feat: gate reverse-mortgage LTV qualify indicator behind split-test flag

### DIFF
--- a/src/app/reverse-mortgage-calculator/results/page.tsx
+++ b/src/app/reverse-mortgage-calculator/results/page.tsx
@@ -7,6 +7,10 @@ import { useFunnelLayout } from '@/hooks/useFunnelFooter'
 import { initializeTracking, trackPageView, trackGA4Event } from '@/lib/temp-tracking'
 import { FAQ } from '@/components/quiz/FAQ'
 import { VerifyPropertyDetails, MAX_QUALIFYING_LTV } from '@/components/reverse-mortgage/VerifyPropertyDetails'
+import {
+  getAssignedLtvIndicatorVariant,
+  type LtvIndicatorVariant,
+} from '@/utils/variant-assignment'
 
 const STORAGE_KEY = 'reverse_mortgage_calculator'
 
@@ -98,6 +102,14 @@ export default function ReverseMortgageResultsPage() {
   const [batchData, setBatchData] = useState<{ property?: PropertyData; state?: string; lookupFailed: boolean }>({
     lookupFailed: false,
   })
+
+  // LTV pass/fail indicator A/B (see variant-assignment.ts). Default 'hidden'
+  // matches both SSR and the current 100%-off rollout.
+  const [ltvIndicatorVariant, setLtvIndicatorVariant] =
+    useState<LtvIndicatorVariant>('hidden')
+  useEffect(() => {
+    setLtvIndicatorVariant(getAssignedLtvIndicatorVariant())
+  }, [])
 
   // Fire LynqFlux delivery + Meta CAPI ViewContent with the given property values.
   // Used for both the BatchData-trusted path and the user-verified path.
@@ -444,6 +456,7 @@ export default function ReverseMortgageResultsPage() {
         lookupFailed={batchData.lookupFailed}
         onConfirm={handleVerifyConfirm}
         isSubmitting={phase === 'submitting_verify'}
+        showQualifyIndicator={ltvIndicatorVariant === 'shown'}
       />
     )
   }

--- a/src/components/reverse-mortgage/PropertyVerificationStep.tsx
+++ b/src/components/reverse-mortgage/PropertyVerificationStep.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useState } from 'react'
 import { Loader2, Home } from 'lucide-react'
 import { VerifyPropertyDetails } from './VerifyPropertyDetails'
+import {
+  getAssignedLtvIndicatorVariant,
+  type LtvIndicatorVariant,
+} from '@/utils/variant-assignment'
 
 interface PropertyData {
   property_value: number
@@ -50,6 +54,14 @@ export function PropertyVerificationStep({
   // The original BatchData LTV (before any user adjustment) — captured here so
   // we can pass it to onConfirm for downstream defensive gating decisions.
   const [batchDataLtv, setBatchDataLtv] = useState<number | undefined>(undefined)
+
+  // LTV pass/fail indicator A/B (see variant-assignment.ts). Default 'hidden'
+  // matches both SSR and the current 100%-off rollout.
+  const [ltvIndicatorVariant, setLtvIndicatorVariant] =
+    useState<LtvIndicatorVariant>('hidden')
+  useEffect(() => {
+    setLtvIndicatorVariant(getAssignedLtvIndicatorVariant())
+  }, [])
 
   useEffect(() => {
     let cancelled = false
@@ -142,6 +154,7 @@ export function PropertyVerificationStep({
         onConfirm({ ...values, batchDataUsed: !lookupFailed, batchDataLtv })
       }
       isSubmitting={isSubmitting}
+      showQualifyIndicator={ltvIndicatorVariant === 'shown'}
     />
   )
 }

--- a/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
+++ b/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
@@ -17,6 +17,16 @@ interface VerifyPropertyDetailsProps {
    * for use inside an existing card (e.g. the quiz step container).
    */
   chrome?: 'page' | 'embedded'
+  /**
+   * Whether to render the pass/fail qualify indicator (green/amber color, icon,
+   * "Looks like a fit" / "lower than typical" copy) alongside the LTV % readout.
+   *
+   * Gated behind the `ss_ltv_indicator_variant` split test in
+   * variant-assignment.ts. Default `false` — caller must opt in. When `false`
+   * the box still renders the LTV %, but in neutral styling with no qualify
+   * signal.
+   */
+  showQualifyIndicator?: boolean
 }
 
 const PROPERTY_MIN = 100_000
@@ -41,6 +51,7 @@ export function VerifyPropertyDetails({
   onConfirm,
   isSubmitting = false,
   chrome = 'page',
+  showQualifyIndicator = false,
 }: VerifyPropertyDetailsProps) {
   const [propertyValue, setPropertyValue] = useState<number>(
     Math.min(Math.max(initialPropertyValue || 400_000, PROPERTY_MIN), PROPERTY_MAX)
@@ -151,31 +162,54 @@ export function VerifyPropertyDetails({
                 </div>
               </div>
 
-              {/* LTV readout + qualify indicator (no proceeds dollars by design) */}
+              {/* LTV readout. The pass/fail qualify styling (color + icon + copy) is
+                * gated behind the ss_ltv_indicator_variant flag in variant-assignment.ts.
+                * When showQualifyIndicator is false (default + current rollout) we keep
+                * the LTV % readout but in neutral styling — no green/amber, no icon, no
+                * qualifying sentence. */}
               <div
                 className={`rounded-xl border-2 p-5 transition-colors ${
-                  qualifies ? 'border-green-300 bg-green-50' : 'border-amber-300 bg-amber-50'
+                  showQualifyIndicator
+                    ? qualifies
+                      ? 'border-green-300 bg-green-50'
+                      : 'border-amber-300 bg-amber-50'
+                    : 'border-gray-200 bg-gray-50'
                 }`}
                 aria-live="polite"
               >
                 <div className="flex items-center gap-3">
-                  {qualifies ? (
-                    <CheckCircle className="h-6 w-6 text-green-600 shrink-0" />
-                  ) : (
-                    <AlertTriangle className="h-6 w-6 text-amber-600 shrink-0" />
-                  )}
+                  {showQualifyIndicator &&
+                    (qualifies ? (
+                      <CheckCircle className="h-6 w-6 text-green-600 shrink-0" />
+                    ) : (
+                      <AlertTriangle className="h-6 w-6 text-amber-600 shrink-0" />
+                    ))}
                   <div className="flex-1">
                     <p className="text-sm font-semibold text-gray-700">
                       Your current loan-to-value:{' '}
-                      <span className={`text-base ${qualifies ? 'text-green-700' : 'text-amber-700'}`}>
+                      <span
+                        className={`text-base ${
+                          showQualifyIndicator
+                            ? qualifies
+                              ? 'text-green-700'
+                              : 'text-amber-700'
+                            : 'text-gray-800'
+                        }`}
+                      >
                         {ltvPct}%
                       </span>
                     </p>
-                    <p className={`text-sm mt-0.5 ${qualifies ? 'text-green-700' : 'text-amber-700'}`}>
-                      {qualifies
-                        ? 'Looks like a fit — a specialist can confirm your exact proceeds.'
-                        : 'Your equity is lower than typical for this program — a specialist will explore the right options for your situation.'}
-                    </p>
+                    {showQualifyIndicator && (
+                      <p
+                        className={`text-sm mt-0.5 ${
+                          qualifies ? 'text-green-700' : 'text-amber-700'
+                        }`}
+                      >
+                        {qualifies
+                          ? 'Looks like a fit — a specialist can confirm your exact proceeds.'
+                          : 'Your equity is lower than typical for this program — a specialist will explore the right options for your situation.'}
+                      </p>
+                    )}
                   </div>
                 </div>
               </div>

--- a/src/utils/variant-assignment.ts
+++ b/src/utils/variant-assignment.ts
@@ -148,3 +148,101 @@ export function clearEntryVariantCookie(): void {
   document.cookie = `${ENTRY_VARIANT_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
 }
 
+// ---------------------------------------------------------------------------
+// LTV pass/fail indicator on the Verify Property step (reverse-mortgage funnel)
+// ---------------------------------------------------------------------------
+// Controls whether the green/amber "Looks like a fit" / "Your equity is lower
+// than typical" qualify box is rendered alongside the LTV % readout in
+// VerifyPropertyDetails.tsx.
+//
+// Hypothesis: the explicit pass/fail signal may cause friction (users who see
+// the amber box may bounce before the lead is captured). The hidden variant
+// keeps the same LTV % readout but in neutral styling, with no icon or
+// qualifying copy.
+//
+// Rollout:
+//   - Today: LTV_INDICATOR_ROLLOUT_SPLIT = false → 100% 'hidden'. The flag is
+//     wired end-to-end but the experiment is not active yet.
+//   - To start the A/B: flip LTV_INDICATOR_ROLLOUT_SPLIT to true. Cookie
+//     assignment is sticky for 30 days, so users in flight stay in their
+//     variant.
+//   - Force a variant for QA / preview: ?ltv_indicator=shown or
+//     ?ltv_indicator=hidden in the URL.
+// ---------------------------------------------------------------------------
+
+export type LtvIndicatorVariant = 'hidden' | 'shown';
+
+const LTV_INDICATOR_COOKIE_NAME = 'ss_ltv_indicator_variant';
+const LTV_INDICATOR_ROLLOUT_SPLIT = false;
+
+/**
+ * Get assigned LTV indicator variant for current session.
+ * Priority: Query param > Cookie > Rollout assignment (today: 100% hidden).
+ */
+export function getAssignedLtvIndicatorVariant(): LtvIndicatorVariant {
+  if (typeof window === 'undefined') {
+    return 'hidden'; // SSR default — matches the post-rollout default state
+  }
+
+  // Check query parameter override (QA / preview)
+  const urlParams = new URLSearchParams(window.location.search);
+  const queryVariant = urlParams.get('ltv_indicator');
+  if (queryVariant === 'shown' || queryVariant === 'hidden') {
+    setLtvIndicatorVariantCookie(queryVariant);
+    return queryVariant;
+  }
+
+  // Check existing cookie
+  const cookieVariant = getLtvIndicatorVariantCookie();
+  if (cookieVariant) {
+    return cookieVariant;
+  }
+
+  // Rollout assignment. While LTV_INDICATOR_ROLLOUT_SPLIT is false, everyone
+  // gets 'hidden' — the flag is staged but the A/B isn't running. Flip to true
+  // to start the 50/50 split.
+  const assigned: LtvIndicatorVariant = LTV_INDICATOR_ROLLOUT_SPLIT
+    ? (Math.random() < 0.5 ? 'shown' : 'hidden')
+    : 'hidden';
+  setLtvIndicatorVariantCookie(assigned);
+  return assigned;
+}
+
+/**
+ * Get LTV indicator variant from cookie
+ */
+function getLtvIndicatorVariantCookie(): LtvIndicatorVariant | null {
+  if (typeof document === 'undefined') return null;
+
+  const cookies = document.cookie.split(';');
+  for (const cookie of cookies) {
+    const [name, value] = cookie.trim().split('=');
+    if (name === LTV_INDICATOR_COOKIE_NAME) {
+      if (value === 'shown' || value === 'hidden') {
+        return value;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Set LTV indicator variant cookie with 30-day TTL
+ */
+function setLtvIndicatorVariantCookie(variant: LtvIndicatorVariant): void {
+  if (typeof document === 'undefined') return;
+
+  const expires = new Date();
+  expires.setTime(expires.getTime() + VARIANT_COOKIE_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+  document.cookie = `${LTV_INDICATOR_COOKIE_NAME}=${variant}; expires=${expires.toUTCString()}; path=/; SameSite=Lax`;
+}
+
+/**
+ * Clear LTV indicator variant cookie (for testing)
+ */
+export function clearLtvIndicatorVariantCookie(): void {
+  if (typeof document === 'undefined') return;
+  document.cookie = `${LTV_INDICATOR_COOKIE_NAME}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+}
+


### PR DESCRIPTION
## Summary
- Adds `LtvIndicatorVariant` ('hidden' | 'shown') to `src/utils/variant-assignment.ts` alongside the existing `QuizVariant` and `EntryVariant` dimensions. Cookie `ss_ltv_indicator_variant`, query-param override `?ltv_indicator=shown|hidden`, 30-day TTL.
- Threads the variant into `VerifyPropertyDetails` via a new optional `showQualifyIndicator` prop (default `false`). When `false`, the box still renders the LTV % readout but in neutral gray styling — no green/amber, no icon, no "Looks like a fit" / "lower than typical" copy.
- Wired into both call sites: the inline quiz `PropertyVerificationStep` and the standalone `reverse-mortgage-calculator/results` page.

## Rollout (staged, not running)
```ts
const LTV_INDICATOR_ROLLOUT_SPLIT = false;
```
While that boolean is `false`, **everyone is assigned `'hidden'`** — the flag is wired end-to-end but the experiment isn't active. Flip to `true` to start the 50/50 split with no other code changes. Cookie assignment is sticky for 30 days, so users in flight stay in their bucket.

QA / preview: `?ltv_indicator=shown` or `?ltv_indicator=hidden` forces a bucket and sets the sticky cookie.

## Scope (intentionally narrow)
- ✅ The colored qualify box on Verify Property step (gated)
- ❌ `/not-qualified` redirect (results/page.tsx:373) — **unchanged**
- ❌ Server-side CAPI LTV gate (submit-without-otp/route.ts) — **unchanged**
- `MAX_QUALIFYING_LTV` still drives buyer1-fit logic and the not-qualified redirect.

## Hypothesis
The explicit "you don't qualify" amber box on the verify step adds friction for high-LTV users — they bounce before the lead is captured. Hiding it lets us collect the equity data silently and apply qualification decisions downstream (CAPI gate, not-qualified redirect) without telegraphing them to the user up front.

## Test plan
- [ ] Visit `/reverse-mortgage-calculator/results` mid-flow → confirm the LTV box renders in neutral gray with the LTV % only (no green/amber, no icon, no qualifying sentence).
- [ ] Visit `?ltv_indicator=shown` → confirm green/amber pass-fail behavior is restored (icon + copy).
- [ ] Visit `?ltv_indicator=hidden` → confirm cookie is set and neutral box renders.
- [ ] Clear cookies, reload → confirm default is neutral.
- [ ] Confirm `/not-qualified` redirect still fires for users with LTV > 0.35 (unchanged behavior).
- [ ] Confirm Meta CAPI Lead events still gate at LTV ≤ 0.50 server-side (unchanged behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)