### PR TITLE
fix(batchdata): sanitize ZIP+4; chore(quiz-rmd): caller-override funnel_type + log DB errors

### DIFF
--- a/src/app/api/batchdata/lookup/route.ts
+++ b/src/app/api/batchdata/lookup/route.ts
@@ -108,19 +108,29 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    log('📊 Request parameters', { address, city, state, zip, place_id })
+    log('📊 Request parameters', { 
+        address, 
+        city, 
+        state, 
+        zip, 
+        has_place_id: !!place_id,
+        // Sanitize ZIP for common lookup issues (ZIP+4)
+        sanitized_zip: zip?.split('-')[0]
+    })
 
     const batchDataKey = process.env.BATCHDATA_LOOKUP_ONLY_KEY
 
     if (!batchDataKey) {
-      log('⚠️ No API key configured')
+      log('⚠️ CRITICAL: BATCHDATA_LOOKUP_ONLY_KEY is NOT set in environment variables')
       return NextResponse.json(
         {
           success: false,
-          error: 'BatchData API key not configured',
+          error: 'BatchData API key not configured. Please check Vercel environment variables.',
         },
         { status: 500 }
       )
+    } else {
+      log('🔑 API key detected (length: ' + batchDataKey.length + ')')
     }
 
     // Construct the full address for lookup
@@ -156,7 +166,7 @@ export async function POST(request: NextRequest) {
                 street: address,
                 city: city,
                 state: state,
-                zip: zip,
+                zip: zip.split('-')[0], // Use 5-digit ZIP for maximum compatibility
               },
             },
           ],
@@ -167,18 +177,22 @@ export async function POST(request: NextRequest) {
 
     if (!batchDataResponse.ok) {
       const errorText = await batchDataResponse.text()
-      log('❌ External API error', {
+      log('❌ BatchData API error', {
         status: batchDataResponse.status,
+        statusText: batchDataResponse.statusText,
         error: errorText,
+        address: address,
+        zip: zip
       })
 
       return NextResponse.json(
         {
           success: false,
-          error: 'Unable to retrieve property data. Please verify the address and try again.',
+          error: `BatchData API error (${batchDataResponse.status}): ${errorText.substring(0, 100)}`,
+          status: batchDataResponse.status,
           data: null,
         },
-        { status: 500 }
+        { status: 502 } // Use 502 Bad Gateway for external API failure
       )
     }
 

--- a/src/app/api/leads/quiz-rmd/route.ts
+++ b/src/app/api/leads/quiz-rmd/route.ts
@@ -97,7 +97,8 @@ async function upsertLead(
   sessionId: string | null,
   quizAnswers: any,
   utmParams: any,
-  trustedFormCertUrl?: string | null
+  trustedFormCertUrl?: string | null,
+  funnelType?: string
 ) {
   const verifiedAt = new Date().toISOString();
   
@@ -167,7 +168,7 @@ async function upsertLead(
     contact_id: contactId,
     session_id: sessionId,
     site_key: 'seniorsimple.org',
-    funnel_type: 'rmd-quiz',
+    funnel_type: funnelType || 'rmd-quiz', // Default matches this route's funnel; caller may override
     status: 'verified',
     is_verified: true,
     verified_at: verifiedAt,
@@ -197,7 +198,15 @@ async function upsertLead(
       .select('*')
       .single();
     
-    if (error) throw error;
+    if (error) {
+      console.error('❌ Database error updating lead:', {
+        error: error.message,
+        code: error.code,
+        leadId: existingLead.id,
+        funnelType
+      });
+      throw error;
+    }
     return updated || existingLead;
   } else {
     const { data: newLead, error } = await callreadyQuizDb
@@ -206,7 +215,15 @@ async function upsertLead(
       .select('*')
       .single();
     
-    if (error) throw error;
+    if (error) {
+      console.error('❌ Database error creating lead:', {
+        error: error.message,
+        code: error.code,
+        session_id: sessionId,
+        funnelType
+      });
+      throw error;
+    }
     return newLead;
   }
 }
@@ -251,7 +268,8 @@ export async function POST(request: NextRequest) {
       sessionId,
       quizAnswers,
       utmParams,
-      trustedFormCertUrl
+      trustedFormCertUrl,
+      body.funnelType || 'rmd-quiz' // Allow caller to override funnel type; default matches this route
     );
 
     // Prepare GHL webhook payload


### PR DESCRIPTION
Two small, independent improvements to the reverse-mortgage funnel backend. Rescued from a long-running WIP stash; the booking-widget refactor in the same stash was discarded (per Keenan, that work is outdated and should stay off prod).

## 1. `fix(batchdata): sanitize ZIP+4 and surface real API failures`
- **ZIP sanitize**: BatchData rejects (or mis-matches) `92105-4510`-style ZIPs. Strip to the leading 5 digits before calling the API.
- **502 on upstream failure**: External-API failures now return 502 Bad Gateway (was 500) so monitoring + the client can tell "our bug" from "BatchData is down or rejecting the address".
- **Surface upstream status + body** (truncated to 100 chars) in the error response instead of the generic "Please verify the address" message.
- **Critical log** when `BATCHDATA_LOOKUP_ONLY_KEY` is missing, with a pointer to Vercel env vars.
- Don't dump full `place_id` on every request; log only its presence.

## 2. `chore(quiz-rmd): allow caller-overridable funnel_type + log DB errors`
- `upsertLead` now accepts an optional `funnelType` arg; default stays `'rmd-quiz'` to match this route's own funnel. **No behavior change for existing callers.** (The stashed version had defaulted to `'reverse-mortgage'`, which would have mis-typed every rmd-quiz lead — explicitly reverted.)
- On Supabase insert/update failure, log the error message + code + the relevant identifiers (leadId on update, session_id on create, funnelType always) before rethrowing. Previously these surfaced as bare 500s with no breadcrumb.

## Test plan
- [ ] Post a real address with a ZIP+4 (e.g. `92105-4510`) to `/api/batchdata/lookup` and confirm BatchData returns property data (currently fails or mis-matches).
- [ ] Post a clearly bad address and confirm response is `502` with upstream status + body in the payload.
- [ ] Confirm the existing reverse-mortgage funnel verify step still resolves property data for normal addresses.
- [ ] Confirm a lead created via `/api/leads/quiz-rmd` still has `funnel_type = 'rmd-quiz'` in Supabase.
- [ ] Confirm tsc passes (already verified locally — exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)