### PR TITLE
fix(verify-property): currency inputs accept key-in without runaway clamp

### DIFF
--- a/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
+++ b/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
@@ -53,11 +53,30 @@ export function VerifyPropertyDetails({
   chrome = 'page',
   showQualifyIndicator = false,
 }: VerifyPropertyDetailsProps) {
-  const [propertyValue, setPropertyValue] = useState<number>(
-    Math.min(Math.max(initialPropertyValue || 400_000, PROPERTY_MIN), PROPERTY_MAX)
+  const initialPropertyClamped = Math.min(
+    Math.max(initialPropertyValue || 400_000, PROPERTY_MIN),
+    PROPERTY_MAX
   )
-  const [mortgageBalance, setMortgageBalance] = useState<number>(
-    Math.max(0, Math.min(initialMortgageBalance ?? 0, propertyValue))
+  const initialMortgageClamped = Math.max(
+    0,
+    Math.min(initialMortgageBalance ?? 0, initialPropertyClamped)
+  )
+
+  const [propertyValue, setPropertyValue] = useState<number>(initialPropertyClamped)
+  const [mortgageBalance, setMortgageBalance] = useState<number>(initialMortgageClamped)
+
+  // Raw text shown in each currency input. Decoupled from the controlled
+  // number so the user can type freely without per-keystroke clamping — old
+  // bug: typing "5" then "0" against a "$400,000" prefill snapped to
+  // "$1,000,000" because parse-clamp-reformat ran on every keystroke and
+  // appended the new digit onto the already-formatted text. Raw text is
+  // committed (parsed + clamped) on blur/Enter, and slider drags also push
+  // the formatted result back into the raw text so the two stay in sync.
+  const [propertyValueRaw, setPropertyValueRaw] = useState<string>(
+    formatCurrency(initialPropertyClamped)
+  )
+  const [mortgageBalanceRaw, setMortgageBalanceRaw] = useState<string>(
+    formatCurrency(initialMortgageClamped)
   )
 
   const ltv = useMemo(
@@ -67,14 +86,22 @@ export function VerifyPropertyDetails({
   const ltvPct = Math.round(ltv * 100)
   const qualifies = ltv <= MAX_QUALIFYING_LTV
 
-  const handlePropertyChange = (next: number) => {
+  // Commit a clamped property value to state AND mirror it into raw text.
+  // Also cascades a max-cap on mortgage balance (mortgage can't exceed home value).
+  const commitPropertyValue = (next: number) => {
     const clamped = Math.min(Math.max(next, PROPERTY_MIN), PROPERTY_MAX)
     setPropertyValue(clamped)
-    if (mortgageBalance > clamped) setMortgageBalance(clamped)
+    setPropertyValueRaw(formatCurrency(clamped))
+    if (mortgageBalance > clamped) {
+      setMortgageBalance(clamped)
+      setMortgageBalanceRaw(formatCurrency(clamped))
+    }
   }
 
-  const handleMortgageChange = (next: number) => {
-    setMortgageBalance(Math.max(0, Math.min(next, propertyValue)))
+  const commitMortgageBalance = (next: number) => {
+    const clamped = Math.max(0, Math.min(next, propertyValue))
+    setMortgageBalance(clamped)
+    setMortgageBalanceRaw(formatCurrency(clamped))
   }
 
   const propertyTrackPct = ((propertyValue - PROPERTY_MIN) / (PROPERTY_MAX - PROPERTY_MIN)) * 100
@@ -104,8 +131,16 @@ export function VerifyPropertyDetails({
                   <input
                     type="text"
                     inputMode="numeric"
-                    value={formatCurrency(propertyValue)}
-                    onChange={(e) => handlePropertyChange(parseCurrency(e.target.value))}
+                    value={propertyValueRaw}
+                    onChange={(e) => setPropertyValueRaw(e.target.value)}
+                    onFocus={(e) => e.currentTarget.select()}
+                    onBlur={() => commitPropertyValue(parseCurrency(propertyValueRaw))}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        e.currentTarget.blur()
+                      }
+                    }}
                     className="w-40 text-right text-lg font-semibold text-[#36596A] border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-[#36596A]/40"
                     aria-label="Estimated home value"
                   />
@@ -116,7 +151,7 @@ export function VerifyPropertyDetails({
                   max={PROPERTY_MAX}
                   step={PROPERTY_STEP}
                   value={propertyValue}
-                  onChange={(e) => handlePropertyChange(Number(e.target.value))}
+                  onChange={(e) => commitPropertyValue(Number(e.target.value))}
                   className="w-full h-3 bg-gray-200 rounded-lg appearance-none cursor-pointer"
                   style={{
                     background: `linear-gradient(to right, #36596A 0%, #36596A ${propertyTrackPct}%, #e5e7eb ${propertyTrackPct}%, #e5e7eb 100%)`,
@@ -138,8 +173,16 @@ export function VerifyPropertyDetails({
                   <input
                     type="text"
                     inputMode="numeric"
-                    value={formatCurrency(mortgageBalance)}
-                    onChange={(e) => handleMortgageChange(parseCurrency(e.target.value))}
+                    value={mortgageBalanceRaw}
+                    onChange={(e) => setMortgageBalanceRaw(e.target.value)}
+                    onFocus={(e) => e.currentTarget.select()}
+                    onBlur={() => commitMortgageBalance(parseCurrency(mortgageBalanceRaw))}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        e.currentTarget.blur()
+                      }
+                    }}
                     className="w-40 text-right text-lg font-semibold text-[#36596A] border border-gray-300 rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-[#36596A]/40"
                     aria-label="Current mortgage balance"
                   />
@@ -150,7 +193,7 @@ export function VerifyPropertyDetails({
                   max={propertyValue}
                   step={MORTGAGE_STEP}
                   value={mortgageBalance}
-                  onChange={(e) => handleMortgageChange(Number(e.target.value))}
+                  onChange={(e) => commitMortgageBalance(Number(e.target.value))}
                   className="w-full h-3 bg-gray-200 rounded-lg appearance-none cursor-pointer"
                   style={{
                     background: `linear-gradient(to right, #36596A 0%, #36596A ${mortgageTrackPct}%, #e5e7eb ${mortgageTrackPct}%, #e5e7eb 100%)`,


### PR DESCRIPTION
## The bug
On the Verify Property step (reverse-mortgage funnel), the home-value and mortgage-balance currency inputs re-clamped + reformatted on **every keystroke**. Typing into them was effectively unusable:

1. Field prefilled with "$400,000". User select-alls, types "5".
2. `parseCurrency("5") = 5` → clamp to `PROPERTY_MIN = 100_000` → field rerenders to "$100,000".
3. User types "0". Browser appends to the rendered string: `"$100,0000"`.
4. `parseCurrency("$100,0000") = 1_000_000` → in range → field shows "$1,000,000".

User intended `$500`. Result: `$1,000,000`. Same pattern broke the mortgage-balance input.

## Fix
- Add `propertyValueRaw` / `mortgageBalanceRaw` string state for each input. Typing only mutates the raw string — no parse, no clamp, no reformat mid-keystroke.
- Commit (`parse + clamp + reformat + sync raw`) on **blur** and on **Enter**.
- Slider drags call the same commit fn so the raw text follows the slider position — both stay in sync.
- `onFocus` auto-selects the input so the user can immediately overtype.
- The cascading constraint (mortgage can't exceed home value) is preserved, and the cascade now also syncs the mortgage raw text.

Slider behavior is unchanged from the user's perspective.

## Test plan
- [ ] Visit the reverse-mortgage verify step. Confirm prefilled values still show as currency.
- [ ] Click home-value input → contents auto-select → type "250000" → tab away → confirm field shows "$250,000".
- [ ] Type "500" → tab away → confirm field clamps to "$100,000" (the min), **not** $1M.
- [ ] Type "5000000" → tab away → confirm field clamps to "$2,000,000" (the max).
- [ ] Press Enter while editing → confirm value commits without form submission.
- [ ] Drag slider → confirm input text updates as slider moves.
- [ ] Set home value high, mortgage near home value, then drag home value down past mortgage → confirm mortgage clamps down AND its input text updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)