### PR TITLE
feat(verify-property): emit funnel telemetry to detect step abandonment

### DIFF
--- a/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
+++ b/src/components/reverse-mortgage/VerifyPropertyDetails.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { CheckCircle, AlertTriangle, Home } from 'lucide-react'
+import { trackGA4Event } from '@/lib/temp-tracking'
 
 export const MAX_QUALIFYING_LTV = 0.35
 
@@ -86,6 +87,98 @@ export function VerifyPropertyDetails({
   const ltvPct = Math.round(ltv * 100)
   const qualifies = ltv <= MAX_QUALIFYING_LTV
 
+  // --- Telemetry -----------------------------------------------------------
+  // Four events fire to GA4 + Supabase analytics_events (via
+  // /api/analytics/track-event). Together they let us measure abandonment
+  // at this step:
+  //   viewed   - mount (denominator)
+  //   engaged  - first interaction of any kind (slider or input)
+  //   manual_entry - text input was actually typed into (per-field commit)
+  //   confirmed - Confirm button clicked
+  //
+  // Funnel:    viewed → engaged → confirmed
+  // Drop-offs: viewed-without-engaged (saw it, didn't touch);
+  //            engaged-without-confirmed (started editing, bailed).
+  // manual_entry is a per-field marker letting us compare typers vs slider-
+  // only users — useful since this step ships with the previously-broken
+  // currency input (PR #10).
+  const mountedAtRef = useRef<number>(Date.now())
+  const viewFiredRef = useRef(false)
+  const engagedFiredRef = useRef(false)
+  const propertyTypedRef = useRef(false)
+  const mortgageTypedRef = useRef(false)
+  const propertyFocusValueRef = useRef<number>(initialPropertyClamped)
+  const mortgageFocusValueRef = useRef<number>(initialMortgageClamped)
+  const manualEntryCountRef = useRef(0)
+  const interactionCountRef = useRef(0)
+
+  const fireVerifyEvent = (
+    eventName: string,
+    extra: Record<string, any> = {},
+    opts: { keepalive?: boolean } = {}
+  ) => {
+    const basePayload = {
+      home_value: propertyValue,
+      mortgage_balance: mortgageBalance,
+      ltv: Number(ltv.toFixed(4)),
+      ltv_pct: ltvPct,
+      lookup_failed: lookupFailed,
+      elapsed_ms_since_view: Date.now() - mountedAtRef.current,
+      manual_entry_count: manualEntryCountRef.current,
+      interaction_count: interactionCountRef.current,
+      source: 'verify-property',
+      ...extra,
+    }
+    try {
+      trackGA4Event(eventName, basePayload)
+    } catch (err) {
+      console.warn('[verify-property] GA4 track failed:', err)
+    }
+    if (typeof window === 'undefined') return
+    const sessionId = window.sessionStorage?.getItem('session_id') || ''
+    if (!sessionId) return
+    try {
+      fetch('/api/analytics/track-event', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        keepalive: opts.keepalive ?? false,
+        body: JSON.stringify({
+          event_name: eventName,
+          properties: basePayload,
+          session_id: sessionId,
+          user_id: sessionId,
+          page_url: window.location.href,
+          referrer: typeof document !== 'undefined' ? document.referrer : '',
+          user_agent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
+          event_category: 'quiz_step',
+          event_label: 'verify_property',
+        }),
+      }).catch(err => console.warn('[verify-property] track failed:', err))
+    } catch (err) {
+      console.warn('[verify-property] track error:', err)
+    }
+  }
+
+  // Fire 'viewed' once on mount. Captures the starting state so we can tell
+  // whether the user saw a BatchData prefill or an empty form (lookupFailed).
+  useEffect(() => {
+    if (viewFiredRef.current) return
+    viewFiredRef.current = true
+    fireVerifyEvent('verify_property_viewed', {
+      initial_home_value: initialPropertyClamped,
+      initial_mortgage_balance: initialMortgageClamped,
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const markEngaged = (control: 'slider' | 'input', field: 'home_value' | 'mortgage_balance') => {
+    interactionCountRef.current += 1
+    if (engagedFiredRef.current) return
+    engagedFiredRef.current = true
+    fireVerifyEvent('verify_property_engaged', { first_control: control, first_field: field })
+  }
+  // -------------------------------------------------------------------------
+
   // Commit a clamped property value to state AND mirror it into raw text.
   // Also cascades a max-cap on mortgage balance (mortgage can't exceed home value).
   const commitPropertyValue = (next: number) => {
@@ -132,9 +225,35 @@ export function VerifyPropertyDetails({
                     type="text"
                     inputMode="numeric"
                     value={propertyValueRaw}
-                    onChange={(e) => setPropertyValueRaw(e.target.value)}
-                    onFocus={(e) => e.currentTarget.select()}
-                    onBlur={() => commitPropertyValue(parseCurrency(propertyValueRaw))}
+                    onChange={(e) => {
+                      setPropertyValueRaw(e.target.value)
+                      propertyTypedRef.current = true
+                      markEngaged('input', 'home_value')
+                    }}
+                    onFocus={(e) => {
+                      e.currentTarget.select()
+                      propertyFocusValueRef.current = propertyValue
+                      propertyTypedRef.current = false
+                    }}
+                    onBlur={() => {
+                      const parsed = parseCurrency(propertyValueRaw)
+                      const before = propertyFocusValueRef.current
+                      commitPropertyValue(parsed)
+                      if (propertyTypedRef.current) {
+                        manualEntryCountRef.current += 1
+                        const clamped = Math.min(Math.max(parsed, PROPERTY_MIN), PROPERTY_MAX)
+                        fireVerifyEvent('verify_property_manual_entry', {
+                          field: 'home_value',
+                          before,
+                          typed_raw: propertyValueRaw,
+                          parsed,
+                          after: clamped,
+                          clamped_to_min: parsed < PROPERTY_MIN,
+                          clamped_to_max: parsed > PROPERTY_MAX,
+                        })
+                        propertyTypedRef.current = false
+                      }
+                    }}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
                         e.preventDefault()
@@ -151,7 +270,10 @@ export function VerifyPropertyDetails({
                   max={PROPERTY_MAX}
                   step={PROPERTY_STEP}
                   value={propertyValue}
-                  onChange={(e) => commitPropertyValue(Number(e.target.value))}
+                  onChange={(e) => {
+                    commitPropertyValue(Number(e.target.value))
+                    markEngaged('slider', 'home_value')
+                  }}
                   className="w-full h-3 bg-gray-200 rounded-lg appearance-none cursor-pointer"
                   style={{
                     background: `linear-gradient(to right, #36596A 0%, #36596A ${propertyTrackPct}%, #e5e7eb ${propertyTrackPct}%, #e5e7eb 100%)`,
@@ -174,9 +296,35 @@ export function VerifyPropertyDetails({
                     type="text"
                     inputMode="numeric"
                     value={mortgageBalanceRaw}
-                    onChange={(e) => setMortgageBalanceRaw(e.target.value)}
-                    onFocus={(e) => e.currentTarget.select()}
-                    onBlur={() => commitMortgageBalance(parseCurrency(mortgageBalanceRaw))}
+                    onChange={(e) => {
+                      setMortgageBalanceRaw(e.target.value)
+                      mortgageTypedRef.current = true
+                      markEngaged('input', 'mortgage_balance')
+                    }}
+                    onFocus={(e) => {
+                      e.currentTarget.select()
+                      mortgageFocusValueRef.current = mortgageBalance
+                      mortgageTypedRef.current = false
+                    }}
+                    onBlur={() => {
+                      const parsed = parseCurrency(mortgageBalanceRaw)
+                      const before = mortgageFocusValueRef.current
+                      commitMortgageBalance(parsed)
+                      if (mortgageTypedRef.current) {
+                        manualEntryCountRef.current += 1
+                        const clamped = Math.max(0, Math.min(parsed, propertyValue))
+                        fireVerifyEvent('verify_property_manual_entry', {
+                          field: 'mortgage_balance',
+                          before,
+                          typed_raw: mortgageBalanceRaw,
+                          parsed,
+                          after: clamped,
+                          clamped_to_min: parsed < 0,
+                          clamped_to_max: parsed > propertyValue,
+                        })
+                        mortgageTypedRef.current = false
+                      }
+                    }}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter') {
                         e.preventDefault()
@@ -193,7 +341,10 @@ export function VerifyPropertyDetails({
                   max={propertyValue}
                   step={MORTGAGE_STEP}
                   value={mortgageBalance}
-                  onChange={(e) => commitMortgageBalance(Number(e.target.value))}
+                  onChange={(e) => {
+                    commitMortgageBalance(Number(e.target.value))
+                    markEngaged('slider', 'mortgage_balance')
+                  }}
                   className="w-full h-3 bg-gray-200 rounded-lg appearance-none cursor-pointer"
                   style={{
                     background: `linear-gradient(to right, #36596A 0%, #36596A ${mortgageTrackPct}%, #e5e7eb ${mortgageTrackPct}%, #e5e7eb 100%)`,
@@ -259,7 +410,18 @@ export function VerifyPropertyDetails({
             </div>
 
             <button
-              onClick={() => onConfirm({ propertyValue, mortgageBalance, ltv })}
+              onClick={() => {
+                // Fire confirmed BEFORE handing off — onConfirm navigates away in
+                // both call sites. keepalive lets the fetch survive the unload.
+                fireVerifyEvent(
+                  'verify_property_confirmed',
+                  {
+                    qualifies, // based on MAX_QUALIFYING_LTV at submit time
+                  },
+                  { keepalive: true }
+                )
+                onConfirm({ propertyValue, mortgageBalance, ltv })
+              }}
               disabled={isSubmitting || propertyValue <= 0}
               className="mt-8 w-full bg-[#36596A] text-white py-3 px-6 rounded-lg font-semibold hover:bg-[#2a4a5a] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >


### PR DESCRIPTION
## Why
We have no visibility into who's bailing on the Verify Property step. We need to know: did they see it, did they touch it, did they type or slide, did they submit. Without these signals we're flying blind on the LTV-indicator A/B (PR #8) and on whether the input-keyin fix (PR #10) actually helped.

## Events (all → GA4 + Supabase \`analytics_events\` via \`/api/analytics/track-event\`)

| Event | Fires | Once-per-mount |
|---|---|---|
| \`verify_property_viewed\` | Component mounts | ✓ |
| \`verify_property_engaged\` | First interaction of any kind (slider drag or input edit) | ✓ |
| \`verify_property_manual_entry\` | Text input blurred *after* being typed into | per field commit |
| \`verify_property_confirmed\` | Confirm button clicked (before \`onConfirm\` navigates away; \`keepalive: true\` so the fetch survives unload) | ✓ |

## Properties on every event
\`home_value\`, \`mortgage_balance\`, \`ltv\`, \`ltv_pct\`, \`lookup_failed\`, \`elapsed_ms_since_view\`, \`manual_entry_count\`, \`interaction_count\`, \`source: "verify-property"\`.

Event-specific:
- \`viewed\`: \`initial_home_value\`, \`initial_mortgage_balance\`
- \`engaged\`: \`first_control\` (slider|input), \`first_field\` (home_value|mortgage_balance)
- \`manual_entry\`: \`field\`, \`before\`, \`typed_raw\`, \`parsed\`, \`after\`, \`clamped_to_min\`, \`clamped_to_max\`
- \`confirmed\`: \`qualifies\` (LTV ≤ 0.35 at submit time)

## Sample analysis SQL
\`\`\`sql
-- Funnel: viewed → engaged → confirmed (last 7 days)
SELECT
  event_name,
  COUNT(DISTINCT session_id) AS sessions
FROM analytics_events
WHERE event_name IN ('verify_property_viewed','verify_property_engaged','verify_property_confirmed')
  AND created_at >= now() - interval '7 days'
GROUP BY 1 ORDER BY 1;

-- Typers vs sliders among engaged sessions
SELECT
  COUNT(DISTINCT CASE WHEN m.session_id IS NOT NULL THEN e.session_id END) AS typed,
  COUNT(DISTINCT e.session_id) AS engaged
FROM analytics_events e
LEFT JOIN analytics_events m
  ON m.session_id = e.session_id AND m.event_name = 'verify_property_manual_entry'
WHERE e.event_name = 'verify_property_engaged'
  AND e.created_at >= now() - interval '7 days';

-- Sessions where the user typed a value below the clamp floor (would've felt buggy)
SELECT session_id, properties->>'field', properties->>'typed_raw', properties->>'parsed', properties->>'after'
FROM analytics_events
WHERE event_name = 'verify_property_manual_entry'
  AND (properties->>'clamped_to_min')::bool IS TRUE
  AND created_at >= now() - interval '7 days';
\`\`\`

## Non-blocking
All tracking is wrapped in try/catch + \`.catch\` on the fetch; failures are \`console.warn\`'d and never thrown. Confirm flow is unaffected if Supabase is down.

## Test plan
- [ ] Visit \`/reverse-mortgage-calculator/results\` mid-flow → confirm \`verify_property_viewed\` lands in Supabase \`analytics_events\` with the prefilled values in \`properties\`.
- [ ] Drag the home-value slider → confirm \`verify_property_engaged\` lands once with \`first_control: "slider"\`. Drag mortgage slider → confirm no second engaged event.
- [ ] Click home-value input → type \`250000\` → tab away → confirm \`verify_property_manual_entry\` with \`parsed: 250000\`, \`after: 250000\`, \`clamped_to_min: false\`.
- [ ] Click home-value → type \`500\` → tab away → confirm \`manual_entry\` with \`parsed: 500\`, \`after: 100000\`, \`clamped_to_min: true\`.
- [ ] Click Confirm → confirm \`verify_property_confirmed\` lands with non-zero \`elapsed_ms_since_view\` and \`manual_entry_count\` matching how many times you typed.
- [ ] Confirm GA4 DebugView shows the same events client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)