### PR TITLE
fix(capi-lead-gate): allow LTV=0 paid-off homes to fire Meta Lead

### DIFF
--- a/src/app/api/leads/submit-without-otp/route.ts
+++ b/src/app/api/leads/submit-without-otp/route.ts
@@ -803,18 +803,28 @@ export async function POST(request: NextRequest) {
     // Defensive server-side LTV gate (reverse-mortgage only). The client only
     // sends capiEventId when its gate passes, but we re-check using the stored
     // verifiedProperty in case the client payload was tampered with or stale.
+    //
+    // Signal check uses propertyValue (not ltv) — a paid-off home is LTV = 0
+    // and is the *highest* equity signal; the old `gatingLtv > 0` guard
+    // silently excluded those leads. We now require a real propertyValue to
+    // signal "user verified the step" and let LTV = 0 fire.
     let reverseMortgageServerGated = false;
     if (isReverseMortgage && body.capiEventId) {
       const vp = quizAnswers?.verifiedProperty || {};
       const gatingLtv = Math.max(Number(vp.ltv) || 0, Number(vp.batchDataLtv) || 0);
+      const propertyValue = Number(vp.propertyValue) || 0;
       const LEAD_CEILING = 0.50;
-      const serverShouldFire = gatingLtv > 0 && gatingLtv <= LEAD_CEILING;
+      const hasPropertySignal = propertyValue > 0;
+      const serverShouldFire = hasPropertySignal && gatingLtv <= LEAD_CEILING;
       if (!serverShouldFire) {
         reverseMortgageServerGated = true;
         console.log('[Meta CAPI] ⏭️ Skipping Lead event — server LTV re-check failed', {
           leadId: lead.id,
           gatingLtv,
+          propertyValue,
+          hasPropertySignal,
           ceiling: LEAD_CEILING,
+          reason: !hasPropertySignal ? 'no_property_value' : 'ltv_above_ceiling',
         });
       }
     }

--- a/src/app/reverse-mortgage-calculator/page.tsx
+++ b/src/app/reverse-mortgage-calculator/page.tsx
@@ -564,12 +564,18 @@ export default function ReverseMortgageCalculatorPage() {
     // toward the cohort that actually converts with the buyer (low-LTV / high-
     // equity homeowners) instead of every form submit.
     // Defensive max() catches users who adjust numbers downward at step 5.
+    //
+    // Signal check uses propertyValue (not ltv) — a paid-off home is LTV = 0,
+    // which is the *highest* equity signal and must fire. The old `gatingLtv > 0`
+    // guard silently excluded those leads. We now require a real propertyValue
+    // (signals "user verified the step") instead.
     const LEAD_LTV_CEILING = 0.50
     const gatingLtv = Math.max(
       verifiedProperty?.ltv ?? 0,
       verifiedProperty?.batchDataLtv ?? 0,
     )
-    const fireLead = gatingLtv > 0 && gatingLtv <= LEAD_LTV_CEILING
+    const hasPropertySignal = (verifiedProperty?.propertyValue ?? 0) > 0
+    const fireLead = hasPropertySignal && gatingLtv <= LEAD_LTV_CEILING
     // Generated upfront so browser pixel and server CAPI share the same eventID.
     const capiEventId = fireLead
       ? `lead-rm-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
@@ -736,7 +742,11 @@ export default function ReverseMortgageCalculatorPage() {
       } else if (fireLead && leadAlreadyFired) {
         console.log('[Meta CAPI] ⏭️ Skipping browser Lead pixel — already fired this session')
       } else if (!fireLead) {
-        console.log(`[Meta CAPI] ⏭️ Skipping browser Lead pixel — LTV ${(gatingLtv * 100).toFixed(1)}% > ${LEAD_LTV_CEILING * 100}% ceiling`)
+        if (!hasPropertySignal) {
+          console.log('[Meta CAPI] ⏭️ Skipping browser Lead pixel — no propertyValue (verifiedProperty missing or 0)')
+        } else {
+          console.log(`[Meta CAPI] ⏭️ Skipping browser Lead pixel — LTV ${(gatingLtv * 100).toFixed(1)}% > ${LEAD_LTV_CEILING * 100}% ceiling`)
+        }
       }
       
       console.log('📊 Lead Submitted Successfully:', {


### PR DESCRIPTION
## The bug

The reverse-mortgage Meta CAPI Lead gate used \`gatingLtv > 0\` as its "we have signal" check. That silently excluded **LTV = 0** — which isn't "no signal", it's the *highest* equity signal possible (a paid-off home, ≥50% equity by definition).

## Real example caught in prod today

Larry Cook, lead \`882264e2-56f5-4801-93fb-76b0cd2108b9\`, 2026-05-29 20:23 UTC:
\`\`\`
verifiedProperty: { propertyValue: 130000, mortgageBalance: 0, ltv: 0 }
leadGate: { gatingLtv: 0, shouldFire: false }
→ CAPI Lead skipped
\`\`\`
70-year-old AR homeowner with $130K paid-off home, found via Meta ad. Textbook buyer-1 fit. Gate silently dropped him.

## The chain

1. Client computed \`gatingLtv = max(0, 0) = 0\`, \`0 > 0\` is false → \`fireLead = false\` → \`capiEventId = undefined\`.
2. Server saw \`!body.capiEventId\` → \`reverseMortgageLeadGated = true\` → skipped CAPI before the defensive recheck even ran.
3. Same bug exists in the server's defensive recheck (\`submit-without-otp/route.ts:811\`), so even fixing only the client would have hit the same bug if the client ever sent a paid-off home through.

## Fix

Replace the \`gatingLtv > 0\` guard with a propertyValue presence check, on both sides:

**Client** (\`reverse-mortgage-calculator/page.tsx\`):
\`\`\`ts
const hasPropertySignal = (verifiedProperty?.propertyValue ?? 0) > 0
const fireLead = hasPropertySignal && gatingLtv <= LEAD_LTV_CEILING
\`\`\`

**Server** (\`submit-without-otp/route.ts\`):
\`\`\`ts
const propertyValue = Number(vp.propertyValue) || 0;
const hasPropertySignal = propertyValue > 0;
const serverShouldFire = hasPropertySignal && gatingLtv <= LEAD_CEILING;
\`\`\`

"We have signal" now means "the user verified a property" — reliably true whenever the verify step completed (BatchData or manual entry). All LTV in [0, 0.50] fires. Same ceiling, same intentional underreporting strategy, just no longer dropping the best leads.

Skip-log messages on both sides updated to distinguish \`no_property_value\` from \`ltv_above_ceiling\` so the next "why didn't this fire" question is one log line away from the answer.

## No behavior change for
- LTV > 0.50 leads (still gated out, correct)
- Non-reverse-mortgage funnels (gate doesn't apply)
- Leads where verifiedProperty is missing entirely (still gated out — `propertyValue ?? 0 = 0`)
- `/not-qualified` redirect at LTV > 0.35 (separate logic, untouched)
- Server's primary \`reverseMortgageLeadGated\` check at \`!body.capiEventId\` — that still works the same way; the client just stops withholding \`capiEventId\` for paid-off homes.

## Impact estimate (post-merge query)

\`\`\`sql
-- How many paid-off-home leads were silently filtered since the gate shipped
SELECT count(*) FROM leads
WHERE funnel_type IN ('reverse-mortgage','reverse-mortgage-calculator')
  AND (quiz_answers->'verifiedProperty'->>'ltv')::numeric = 0
  AND (quiz_answers->'verifiedProperty'->>'propertyValue')::numeric > 0
  AND created_at < '2026-05-29';
\`\`\`

## Test plan
- [ ] Deploy preview. Run the same flow as Larry's lead (paid-off home, propertyValue > 0, mortgage 0, LTV = 0) and confirm:
  - Client-side log shows \`fireLead: true\` and a \`capiEventId\` is generated.
  - Browser fires the Lead pixel.
  - Server \`[Meta CAPI] 🔵 Lead block ENTRY\` shows \`reverseMortgageLeadGated: false\` and the defensive recheck passes.
  - DB row's \`ghl_status.capi_lead_sent\` is a timestamp.
- [ ] Verify LTV = 0.60 paid-off-but-refi'd case still gets gated (above ceiling).
- [ ] Verify verifiedProperty-missing case still gets gated (no signal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)