### PR TITLE
feat(meta-pixel): init reverse-mortgage browser pixel on RM funnel paths

### DIFF
--- a/src/components/tracking/MetaPixelInitializer.tsx
+++ b/src/components/tracking/MetaPixelInitializer.tsx
@@ -2,15 +2,28 @@
 
 import { useEffect } from 'react';
 import { usePathname } from 'next/navigation';
-import { isFEXFunnel, META_PIXEL_IDS } from '@/lib/meta-pixel-config';
+import {
+  isFEXFunnel,
+  isReverseMortgageFunnel,
+  META_PIXEL_IDS,
+} from '@/lib/meta-pixel-config';
 
 /**
  * Client component to initialize Meta Pixel(s) based on current route
- * 
+ *
  * This component:
- * - Detects if we're on a FEX funnel page
- * - Initializes the appropriate pixel(s)
- * - Ensures both pixels can be tracked if needed for attribution
+ * - Always initializes the MAIN SeniorSimple pixel + fires PageView
+ * - On FEX funnel paths, also initializes the FEX pixel
+ * - On reverse-mortgage funnel paths, also initializes the reverse-mortgage
+ *   pixel (when NEXT_PUBLIC_META_PIXEL_ID_REVERSE_MORTGAGE is set) so browser
+ *   PageView + downstream Lead events land on the SAME pixel the server CAPI
+ *   uses. Without this, the RM pixel only ever sees server events → Meta has
+ *   no browser signal to triangulate attribution against → Ads Manager shows
+ *   zero conversions despite events being received.
+ *
+ * When the RM env var is not yet set in Vercel, the RM init is silently
+ * skipped (with a one-line warning so ops knows). PR is therefore safe to
+ * deploy before the env var lands.
  */
 export function MetaPixelInitializer() {
   const pathname = usePathname();
@@ -27,16 +40,19 @@ export function MetaPixelInitializer() {
       // Handle null pathname
       const currentPath = pathname || '/';
       const isFEX = isFEXFunnel(currentPath);
-      
+      const isRM = isReverseMortgageFunnel(currentPath);
+
       console.log('📊 Meta Pixel Initialization:', {
         pathname: currentPath,
         isFEXFunnel: isFEX,
+        isReverseMortgageFunnel: isRM,
         mainPixel: META_PIXEL_IDS.MAIN,
         fexPixel: META_PIXEL_IDS.FEX,
+        rmPixel: META_PIXEL_IDS.REVERSE_MORTGAGE || '(unset)',
       });
 
       // Bot detection
-      const isBot = typeof navigator !== 'undefined' && 
+      const isBot = typeof navigator !== 'undefined' &&
         /bot|crawler|spider|crawling|facebookexternalhit|Googlebot|Bingbot|Slurp|DuckDuckBot|Baiduspider|YandexBot|Sogou|Exabot|facebot|ia_archiver/i.test(navigator.userAgent || '');
 
       if (isBot) {
@@ -61,6 +77,24 @@ export function MetaPixelInitializer() {
           console.log('✅ FEX Meta Pixel initialized:', META_PIXEL_IDS.FEX);
         } catch (error) {
           console.error('❌ Failed to initialize FEX Meta Pixel:', error);
+        }
+      }
+
+      // Initialize reverse-mortgage pixel if on RM funnel AND env var is set.
+      // Otherwise log a one-line warning so the missing env var is obvious.
+      if (isRM) {
+        if (META_PIXEL_IDS.REVERSE_MORTGAGE) {
+          try {
+            window.fbq('init', META_PIXEL_IDS.REVERSE_MORTGAGE);
+            window.fbq('track', 'PageView');
+            console.log('✅ Reverse Mortgage Meta Pixel initialized:', META_PIXEL_IDS.REVERSE_MORTGAGE);
+          } catch (error) {
+            console.error('❌ Failed to initialize Reverse Mortgage Meta Pixel:', error);
+          }
+        } else {
+          console.warn(
+            '⚠️ On reverse-mortgage funnel but NEXT_PUBLIC_META_PIXEL_ID_REVERSE_MORTGAGE is not set — browser pixel will not fire to the RM pixel. Set this env var in Vercel to enable.'
+          );
         }
       }
     };

--- a/src/lib/meta-pixel-config.ts
+++ b/src/lib/meta-pixel-config.ts
@@ -1,15 +1,31 @@
 /**
  * Meta Pixel Configuration for SeniorSimple
- * 
+ *
  * Handles multiple pixel IDs based on funnel type:
- * - Main SeniorSimple pixel: 24221789587508633
- * - Final Expense (FEX) pixel: 1963989871164856
+ * - Main SeniorSimple pixel: 24221789587508633   (hardcoded)
+ * - Final Expense (FEX) pixel: 1963989871164856  (hardcoded)
+ * - Reverse Mortgage pixel: from NEXT_PUBLIC_META_PIXEL_ID_REVERSE_MORTGAGE
+ *
+ * The reverse-mortgage pixel ID is sourced from env (not hardcoded) so it can
+ * be rotated without a code deploy. The server-side `meta-capi-service.ts`
+ * already reads `META_PIXEL_ID_REVERSE_MORTGAGE` for CAPI Lead fires; this
+ * file mirrors it for the BROWSER pixel so client `fbq('init', ...)` lands on
+ * the same pixel the server CAPI events land on. Without this mirror, the
+ * reverse-mortgage pixel only ever sees server events — no browser PageView /
+ * Lead — which crushes Meta's match quality and breaks Ads Manager attribution.
  */
+
+// Note: this is read at module load. NEXT_PUBLIC_* env vars are statically
+// inlined by Next.js at build time, so this resolves to the literal value (or
+// the empty string if unset) in the client bundle.
+const REVERSE_MORTGAGE_PIXEL_ID =
+  process.env.NEXT_PUBLIC_META_PIXEL_ID_REVERSE_MORTGAGE || '';
 
 export const META_PIXEL_IDS = {
   MAIN: '24221789587508633',
   FEX: '1963989871164856',
-} as const;
+  REVERSE_MORTGAGE: REVERSE_MORTGAGE_PIXEL_ID,
+};
 
 /**
  * Check if current path is part of the Final Expense funnel
@@ -25,15 +41,31 @@ export function isFEXFunnel(pathname: string): boolean {
     '/appointment-follow-up',
     '/burial-insurance-guide',
   ];
-  
+
   return fexFunnelPaths.some(path => pathname.startsWith(path));
+}
+
+/**
+ * Check if current path is part of the Reverse Mortgage funnel.
+ *
+ * Covers the full funnel surface: landing, quiz, results, results-alt, and
+ * the not-qualified page. Lets `MetaPixelInitializer` know it should init the
+ * reverse-mortgage pixel (in addition to MAIN) so browser PageView + Lead
+ * fires reach the same pixel the server-side CAPI events use.
+ */
+export function isReverseMortgageFunnel(pathname: string): boolean {
+  return pathname.startsWith('/reverse-mortgage-calculator');
 }
 
 /**
  * Get the appropriate Meta Pixel ID based on the current route
  */
 export function getMetaPixelId(pathname: string): string {
-  return isFEXFunnel(pathname) ? META_PIXEL_IDS.FEX : META_PIXEL_IDS.MAIN;
+  if (isFEXFunnel(pathname)) return META_PIXEL_IDS.FEX;
+  if (isReverseMortgageFunnel(pathname) && META_PIXEL_IDS.REVERSE_MORTGAGE) {
+    return META_PIXEL_IDS.REVERSE_MORTGAGE;
+  }
+  return META_PIXEL_IDS.MAIN;
 }
 
 /**
@@ -41,15 +73,23 @@ export function getMetaPixelId(pathname: string): string {
  */
 export function getActivePixelIds(pathname: string): string[] {
   const pixels: string[] = [];
-  
+
   // Always include main pixel
   pixels.push(META_PIXEL_IDS.MAIN);
-  
+
   // Add FEX pixel if on FEX funnel
   if (isFEXFunnel(pathname)) {
     pixels.push(META_PIXEL_IDS.FEX);
   }
-  
+
+  // Add reverse-mortgage pixel if on RM funnel AND the env var is set. The
+  // env-var guard makes this a safe no-op until ops sets
+  // NEXT_PUBLIC_META_PIXEL_ID_REVERSE_MORTGAGE in Vercel; nothing changes
+  // until that's in place.
+  if (isReverseMortgageFunnel(pathname) && META_PIXEL_IDS.REVERSE_MORTGAGE) {
+    pixels.push(META_PIXEL_IDS.REVERSE_MORTGAGE);
+  }
+
   return pixels;
 }
 


### PR DESCRIPTION
## Why
Server-side CAPI Lead events for the reverse-mortgage funnel fire to a dedicated reverse-mortgage pixel (`META_PIXEL_ID_REVERSE_MORTGAGE` in `meta-capi-service.ts` — `pixelId: "292456..."` as confirmed in today's manual backfire). But the browser pixel initializer only ever inits `MAIN` (`24221789587508633`) and `FEX` (`1963989871164856`). The reverse-mortgage pixel only ever saw server events — no browser `PageView`, no browser `Lead` — which is why the CSV from Events Manager shows `browser_received_count = 0` across every row.

That asymmetry is the root cause of "events received, zero conversions in Ads Manager": Meta has no paired browser signal to triangulate attribution against the server CAPI events.

## What this PR does

**`src/lib/meta-pixel-config.ts`**
- Add `META_PIXEL_IDS.REVERSE_MORTGAGE` sourced from `NEXT_PUBLIC_META_PIXEL_ID_REVERSE_MORTGAGE` (Next.js inlines `NEXT_PUBLIC_*` at build time, so this resolves to a literal in the client bundle).
- Add `isReverseMortgageFunnel(pathname)` matching `/reverse-mortgage-calculator/*` (covers landing, quiz, results, results-alt, not-qualified).
- Update `getMetaPixelId` + `getActivePixelIds` to surface RM where appropriate.

**`src/components/tracking/MetaPixelInitializer.tsx`**
- On RM paths, init the RM pixel and fire `PageView`, in addition to the always-on `MAIN` init.
- If the env var is unset, skip the RM init silently and log a one-line warning. **PR is safe to merge before the env var is set in Vercel** — behavior stays identical to today until the env var lands.

## Required ops action AFTER merge

In Vercel project env vars, add:
\`\`\`
NEXT_PUBLIC_META_PIXEL_ID_REVERSE_MORTGAGE = <same value as the existing META_PIXEL_ID_REVERSE_MORTGAGE>
\`\`\`
The server-side already has the non-public version (proven by today's backfire response showing `pixelId: "292456..."`); we just need the `NEXT_PUBLIC_` mirror so the value reaches the client bundle.

Once that env var is set + a new build deploys, every user on a reverse-mortgage path will fire `PageView` to the RM pixel, AND the existing browser `Lead` fire at `reverse-mortgage-calculator/page.tsx:731` (already deduped via shared `capiEventId`) will land on the same pixel. Browser+server paired with shared event_id → match quality jumps → attribution starts reporting conversions.

## Scope (not in this PR)

The annuity + rmd-quiz funnels fire server CAPI Lead with **no browser counterpart anywhere in the code**. That's the second half of the diagnosis — a separate PR.

## Test plan

After deploy + env var set:
- [ ] Visit `/reverse-mortgage-calculator` in a browser with devtools open. Confirm `📊 Meta Pixel Initialization` log shows `isReverseMortgageFunnel: true` and `rmPixel: 292456...`.
- [ ] Confirm `✅ Reverse Mortgage Meta Pixel initialized: 292456...` log line.
- [ ] In the Network tab, confirm `https://www.facebook.com/tr?id=292456...&ev=PageView&...` request fires.
- [ ] In Meta Events Manager → reverse-mortgage pixel → Test Events, fire a synthetic submission and confirm both browser PageView/Lead AND server CAPI Lead show up under the same event_id (dedup confirmation).
- [ ] Within 24h, check Events Manager analytics — `browser_received_count` should be > 0 on rows where it was previously 0.
- [ ] Within 24-48h, check Ads Manager attribution on the reverse-mortgage campaign — conversions should start being reported.

Before env var set: confirm warning log `⚠️ On reverse-mortgage funnel but NEXT_PUBLIC_META_PIXEL_ID_REVERSE_MORTGAGE is not set...` appears in browser console on RM paths, and existing MAIN pixel behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)