### PR TITLE
fix(newsletter): resolve trivia issue by slug only

### DIFF
--- a/src/app/newsletter/[slug]/trivia/page.tsx
+++ b/src/app/newsletter/[slug]/trivia/page.tsx
@@ -19,8 +19,6 @@ function getSupabase() {
   return _supabase
 }
 
-const SITE_ID = process.env.NEXT_PUBLIC_SITE_ID || 'seniorsimple'
-
 interface LeadArticle {
   category?: string
   title?: string
@@ -50,7 +48,6 @@ async function getIssue(slug: string): Promise<NewsletterIssue | null> {
       .from('newsletter_issues')
       .select('issue_number, subject, sent_at, dynamic_template_data')
       .eq('slug', slug)
-      .eq('site_id', SITE_ID)
       .maybeSingle()
     if (error) {
       console.error('Trivia issue lookup error:', error)


### PR DESCRIPTION
Real issues were rendering the 'not available' card because the trivia query filtered on `site_id = NEXT_PUBLIC_SITE_ID` (unset/mismatched in prod). Slug is unique — read by slug only, matching the existing `/api/poll` and `/poll/results` routes. Verified: the exact PostgREST query returns the row for a real sent issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)