### PR TITLE
fix(poll): read answer label from 'label' param

### DIFF
--- a/src/app/api/poll/route.ts
+++ b/src/app/api/poll/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
   const issueSlug = searchParams.get('issue')
   const questionKey = searchParams.get('q')
   const answerValue = searchParams.get('a')
-  const answerLabel = searchParams.get('al') || answerValue
+  const answerLabel = searchParams.get('al') || searchParams.get('label') || answerValue
   const subscriberId = searchParams.get('sid') || null
 
   const baseUrl = new URL(request.url).origin


### PR DESCRIPTION
Email poll links use `&label=`, but the route only read `&al=`, so results showed the raw value (e.g. `option-1`) instead of the option label. Now reads `al || label || value` — also fixes already-sent emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)