### PR TITLE
fix(articles): gate ScrollRevealedCallButton to Medicare articles

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -225,13 +225,16 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         </div>
       </section>
 
-      {/* Scroll-Revealed Call Button */}
-      {phoneNumber && (
-        <ScrollRevealedCallButton
-          phoneNumber={phoneNumber}
-          serviceName={article.category_details?.name || 'Medicare Services'}
-        />
-      )}
+      {/* Scroll-Revealed Call Button — Medicare articles only.
+          Kill switch: set NEXT_PUBLIC_ENABLE_SCROLL_CALL_BUTTON=false. */}
+      {process.env.NEXT_PUBLIC_ENABLE_SCROLL_CALL_BUTTON !== 'false' &&
+        isMedicareArticle &&
+        phoneNumber && (
+          <ScrollRevealedCallButton
+            phoneNumber={phoneNumber}
+            serviceName={article.category_details?.name || 'Medicare Services'}
+          />
+        )}
 
       {/* Tags */}
       {article.tags && article.tags.length > 0 && (


### PR DESCRIPTION
## Summary
- Gate the scroll-revealed \"Speak with a licensed Medicare advisor\" call button so it only renders on Medicare articles — reuses the existing `isMedicareArticle` predicate at [src/app/articles/[slug]/page.tsx:47](src/app/articles/[slug]/page.tsx#L47) (title/category/tags/slug match)
- Add `NEXT_PUBLIC_ENABLE_SCROLL_CALL_BUTTON` kill switch — set to `\"false\"` in Vercel env to disable everywhere
- Removes a local `{false && phoneNumber && ...}` guard that had been blocking preview builds until stashed at deploy time (broke TS null-narrowing — `article` narrowed to possibly-null after the always-false branch)

## Why
The button reads \"Speak with a licensed Medicare advisor today\" but was showing up on every article page — burial insurance guides, reverse mortgage explainers, retirement content, everything. Off-context CTAs on non-Medicare topics.

## Behaviour
| Article context | phoneNumber | Env flag | Renders? |
|---|---|---|---|
| Medicare (title/category/tag/slug match) | ✓ | unset or `\"true\"` | **✓** |
| Medicare | ✓ | `\"false\"` | ✗ (kill switch) |
| Non-Medicare | ✓ | any | ✗ |
| Any | none | any | ✗ |

## Test plan
- [ ] Load a Medicare article (e.g. any slug/category containing \"medicare\") → button appears on scroll
- [ ] Load a non-Medicare article (burial insurance, reverse mortgage, etc.) → button does NOT appear
- [ ] Set `NEXT_PUBLIC_ENABLE_SCROLL_CALL_BUTTON=false` in Vercel env, redeploy → button disappears even on Medicare
- [ ] `next build` completes without TS null-narrowing error on articles/[slug]/page.tsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)