### PR TITLE
feat(ebook): server API that dual-fires SS+RR GHL and alerts Slack

### DIFF
--- a/src/app/api/ebook/submit/route.ts
+++ b/src/app/api/ebook/submit/route.ts
@@ -13,7 +13,7 @@ type EbookFunnelKey = keyof typeof EBOOK_FUNNELS;
 
 const SENIORSIMPLE_WEBHOOK = process.env.EBOOK_SENIORSIMPLE_GHL_WEBHOOK_URL || '';
 const RETIREMENT_RESCUE_WEBHOOK = process.env.EBOOK_RETIREMENT_RESCUE_GHL_WEBHOOK_URL || '';
-const SLACK_WEBHOOK = process.env.EBOOK_SLACK_WEBHOOK_URL || '';
+const SLACK_WEBHOOK = process.env.SLACK_LEADS_WEBHOOK_URL || '';
 
 // Real fires only on production Vercel deploys. Preview + local simulate.
 const IS_PROD = process.env.VERCEL_ENV === 'production';

--- a/src/app/api/ebook/submit/route.ts
+++ b/src/app/api/ebook/submit/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { callreadyQuizDb } from '@/lib/callready-quiz-db';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const EBOOK_FUNNELS = {
+  'annuity-dos-donts': "Annuity Do's and Don'ts for Baby Boomers",
+  'simple-annuity-strategies': 'Simple Annuity Strategies',
+  'retirement-made-simple': 'Retirement Made Simple',
+} as const;
+type EbookFunnelKey = keyof typeof EBOOK_FUNNELS;
+
+const SENIORSIMPLE_WEBHOOK = process.env.EBOOK_SENIORSIMPLE_GHL_WEBHOOK_URL || '';
+const RETIREMENT_RESCUE_WEBHOOK = process.env.EBOOK_RETIREMENT_RESCUE_GHL_WEBHOOK_URL || '';
+const SLACK_WEBHOOK = process.env.EBOOK_SLACK_WEBHOOK_URL || '';
+
+// Real fires only on production Vercel deploys. Preview + local simulate.
+const IS_PROD = process.env.VERCEL_ENV === 'production';
+
+type SubmitBody = {
+  funnel?: EbookFunnelKey;
+  first_name?: string;
+  email?: string;
+  page_url?: string;
+  utm_session_id?: string | null;
+};
+
+const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+
+function tagsFor(funnel: EbookFunnelKey): string[] {
+  return ['reactivation', `ebook:${funnel}`, 'source:ebook-funnel', 'site:seniorsimple'];
+}
+
+async function fireWebhook(url: string, body: unknown, label: string) {
+  if (!url) return { ok: false, skipped: 'no-url', label };
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) console.warn(`[ebook-submit] ${label} webhook returned ${res.status}`);
+    return { ok: res.ok, status: res.status, label };
+  } catch (err) {
+    console.error(`[ebook-submit] ${label} webhook error`, err);
+    return { ok: false, error: String(err), label };
+  }
+}
+
+export async function POST(req: NextRequest) {
+  let body: SubmitBody;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: 'invalid-json' }, { status: 400 });
+  }
+
+  const funnel = body.funnel;
+  const email = (body.email || '').trim().toLowerCase();
+  const first_name = (body.first_name || '').trim();
+
+  if (!funnel || !EBOOK_FUNNELS[funnel]) {
+    return NextResponse.json({ ok: false, error: 'invalid-funnel' }, { status: 400 });
+  }
+  if (!EMAIL_RE.test(email)) {
+    return NextResponse.json({ ok: false, error: 'invalid-email' }, { status: 400 });
+  }
+
+  const ebook_title = EBOOK_FUNNELS[funnel];
+  const tags = tagsFor(funnel);
+  const now = new Date().toISOString();
+  const page_url = body.page_url || '';
+
+  const { error: contactErr } = await callreadyQuizDb.from('contacts').upsert(
+    {
+      email,
+      first_name,
+      source: 'ebook-funnel',
+      last_activity_at: now,
+      metadata: {
+        ebook_funnel: funnel,
+        ebook_title,
+        campaign: 'list-reactivation',
+        site_key: 'seniorsimple.org',
+        tags,
+      },
+    },
+    { onConflict: 'email' }
+  );
+  if (contactErr) console.error('[ebook-submit] contacts upsert failed', contactErr);
+
+  const { error: eventErr } = await callreadyQuizDb.from('analytics_events').insert({
+    event_name: 'ebook_submit',
+    event_category: 'ebook_funnel',
+    event_label: funnel,
+    session_id: body.utm_session_id || null,
+    page_url,
+    properties: {
+      funnel_type: funnel,
+      ebook_title,
+      campaign: 'list-reactivation',
+      site_key: 'seniorsimple.org',
+      email,
+      first_name,
+      tags,
+    },
+  });
+  if (eventErr) console.error('[ebook-submit] analytics_events insert failed', eventErr);
+
+  const ghlPayload = {
+    first_name,
+    email,
+    tags,
+    ebook_title,
+    ebook_funnel: funnel,
+    campaign: 'list-reactivation',
+    site_key: 'seniorsimple.org',
+    source: 'ebook-funnel',
+    page_url,
+    submitted_at: now,
+  };
+
+  const slackText =
+    `📖 New ebook lead — *${ebook_title}*\n` +
+    `• ${first_name || '(no name)'} <${email}>\n` +
+    `• tags: ${tags.join(', ')}` +
+    (page_url ? `\n• page: ${page_url}` : '');
+
+  if (!IS_PROD) {
+    console.log('[ebook-submit simulated]', { funnel, email, tags });
+    return NextResponse.json({
+      ok: true,
+      simulated: true,
+      would_fire: {
+        seniorsimple_ghl: Boolean(SENIORSIMPLE_WEBHOOK),
+        retirement_rescue_ghl: Boolean(RETIREMENT_RESCUE_WEBHOOK),
+        slack: Boolean(SLACK_WEBHOOK),
+      },
+    });
+  }
+
+  const [ss, rr, sl] = await Promise.all([
+    fireWebhook(SENIORSIMPLE_WEBHOOK, ghlPayload, 'seniorsimple'),
+    fireWebhook(RETIREMENT_RESCUE_WEBHOOK, ghlPayload, 'retirement_rescue'),
+    fireWebhook(SLACK_WEBHOOK, { text: slackText }, 'slack'),
+  ]);
+
+  return NextResponse.json({ ok: true, fired: { seniorsimple: ss, retirement_rescue: rr, slack: sl } });
+}

--- a/src/components/pages/EbookFunnel.tsx
+++ b/src/components/pages/EbookFunnel.tsx
@@ -176,9 +176,7 @@ const FUNNELS: Record<EbookFunnelKey, Funnel> = {
   },
 };
 
-const SUPABASE_FN = 'https://jqjftrlnyysqcwbbigpw.supabase.co/functions/v1/submit-form';
-const ANON =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpxamZ0cmxueXlzcWN3YmJpZ3B3Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTEyOTQ2MzksImV4cCI6MjA2Njg3MDYzOX0.ZqgLIflQJY5zC3ZnU5K9k_KEM9bDdNhtqek6ckuwjAo';
+const SUBMIT_ENDPOINT = '/api/ebook/submit';
 
 const THIRTY_THREE_FOOTNOTE =
   '*Illustrative and educational. “Up to 33%” refers to the combined impact that taxes, fees, and timing decisions can have on retirement income over time, based on the strategies discussed in this guide. Individual results vary and are not guaranteed.';
@@ -195,52 +193,27 @@ const TRUST = [
   { label: 'No Obligation, Ever' },
 ];
 
-function isLiveHost() {
-  if (typeof window === 'undefined') return false;
-  return /seniorsimple\.org$/i.test(window.location.hostname);
-}
-
 async function submitLead(funnelKey: EbookFunnelKey, firstName: string, email: string) {
-  const f = FUNNELS[funnelKey];
   const utm =
     typeof window !== 'undefined' && (window as unknown as { __utmSessionId?: string | null }).__utmSessionId
       ? (window as unknown as { __utmSessionId?: string | null }).__utmSessionId
       : null;
   const body = {
-    contact_info: {
-      first_name: firstName || '',
-      last_name: '',
-      email: email || '',
-      phone: '',
-      zip_code: '',
-    },
-    form_type: 'contact_form',
-    form_data: {
-      lead_magnet: funnelKey,
-      funnel_type: funnelKey,
-      ebook_title: f.ebookTitle,
-      campaign: 'list-reactivation',
-      site_key: 'seniorsimple.org',
-      tcpa_consent: false,
-      consent_language: '',
-      page_url: typeof location !== 'undefined' ? location.href : '',
-      step: 'email_capture',
-    },
+    funnel: funnelKey,
+    first_name: firstName || '',
+    email: email || '',
+    page_url: typeof location !== 'undefined' ? location.href : '',
     utm_session_id: utm,
   };
-  if (!isLiveHost()) {
-    console.log('[submit-form simulated]', 'email_capture', body);
-    return { ok: true, simulated: true };
-  }
   try {
-    const res = await fetch(SUPABASE_FN, {
+    const res = await fetch(SUBMIT_ENDPOINT, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', apikey: ANON, Authorization: 'Bearer ' + ANON },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
     return await res.json();
   } catch (e) {
-    console.error('submit-form error', e);
+    console.error('[ebook-submit] client fetch error', e);
     return { ok: false };
   }
 }


### PR DESCRIPTION
## Summary
New `/api/ebook/submit` route becomes the single source of truth for the SeniorSimple ebook lead capture. Server-side flow per submission:
1. Validate `funnel` (must be one of the three) + email format
2. **Upsert** `contacts` by email — sets `source='ebook-funnel'`, `metadata.ebook_funnel`, `metadata.tags`, `last_activity_at`
3. **Insert** into `analytics_events` — `event_name='ebook_submit'`, `event_category='ebook_funnel'`, `event_label={funnel}`, full props in `properties` jsonb
4. **In parallel** fire three webhooks with the same payload shape: SeniorSimple GHL, Retirement Rescue GHL, Slack incoming
5. Return `{ok: true, fired: {...}}` — one failure never blocks the others

## Tag schema (per spec §4.6)
Every contact gets these tags in `metadata.tags` and every GHL webhook payload includes them in a top-level `tags` array so downstream workflows can 1:1 apply them:
- `reactivation`
- `ebook:{funnel}` — e.g. `ebook:annuity-dos-donts`, `ebook:retirement-made-simple`
- `source:ebook-funnel`
- `site:seniorsimple`

## ⚠️ Required Vercel env vars (add before merging)
The route is safe to merge without these — it just silently skips the missing fires and logs `skipped:no-url`. But it won't fire until you add them in **Production** env only:

| Env var | What | Where you get it |
|---|---|---|
| `EBOOK_SENIORSIMPLE_GHL_WEBHOOK_URL` | Webhook trigger for the SS location workflow | Build a workflow in SS GHL (location `vTM82D7FNpIlnPgw6XNC`) with a webhook trigger and paste the URL |
| `EBOOK_RETIREMENT_RESCUE_GHL_WEBHOOK_URL` | Webhook trigger for the RR location workflow | Build a workflow in RR GHL (location `X8oobII8UPW3hIZhVVlA`) with a webhook trigger and paste the URL |
| `EBOOK_SLACK_WEBHOOK_URL` | Slack incoming webhook for #notifications-leads | Slack app → Incoming Webhooks → Add to #notifications-leads → copy URL |

Supabase writes use the existing `SUPABASE_QUIZ_SERVICE_ROLE_KEY` — no new Supabase config needed.

## Gate: preview + local simulate, prod fires for real
```ts
const IS_PROD = process.env.VERCEL_ENV === 'production';
```
On non-prod (localhost, `*.vercel.app` previews), the route still writes to Supabase but skips the three webhooks and returns `{simulated: true, would_fire: {...}}`. Same route, no surprise fires from preview traffic.

## GHL webhook payload
Each of the two GHL webhooks receives the same JSON:
```json
{
  "first_name": "Margaret",
  "email": "margaret@example.com",
  "tags": ["reactivation", "ebook:annuity-dos-donts", "source:ebook-funnel", "site:seniorsimple"],
  "ebook_title": "Annuity Do's and Don'ts for Baby Boomers",
  "ebook_funnel": "annuity-dos-donts",
  "campaign": "list-reactivation",
  "site_key": "seniorsimple.org",
  "source": "ebook-funnel",
  "page_url": "https://www.seniorsimple.org/ebook/annuity-dos-and-donts",
  "submitted_at": "2026-07-02T17:15:34.220Z"
}
```
Configure each workflow's webhook trigger to map `email` + `first_name` → contact and `tags` → contact tags. Branch on `ebook_funnel` if you want per-book automations.

## Slack payload
```json
{
  "text": "📖 New ebook lead — *Annuity Do's and Don'ts for Baby Boomers*\n• Margaret <margaret@example.com>\n• tags: reactivation, ebook:annuity-dos-donts, source:ebook-funnel, site:seniorsimple\n• page: https://www.seniorsimple.org/ebook/annuity-dos-and-donts"
}
```

## Behaviour change vs main
- **Before**: EbookFunnel POST'd directly to Supabase `submit-form` fn with the anon key baked into the JS bundle. Fn upserts contacts + fires a single webhook (which despite the misleading env-var name actually pointed at RR GHL, not SS).
- **After**: EbookFunnel POSTs to same-origin `/api/ebook/submit`. Anon key no longer in the bundle. SS GHL now gets fired (didn't before). RR GHL now gets tag-aware payload (previously via Supabase fn's payload shape, which may or may not have surfaced tags). Slack alert is new.

## Test plan
- [ ] Local: POST to `http://localhost:3000/api/ebook/submit` with `{funnel:'annuity-dos-donts', first_name:'X', email:'x@example.com'}` → 200 with `simulated:true`
- [ ] Local: verify `contacts` row exists in Supabase for the test email with `source='ebook-funnel'` + tags in metadata (confirmed during dev — 1 test row created + cleaned up)
- [ ] Vercel preview: same POST → 200 with `simulated:true`, `would_fire` reflects which env vars are set
- [ ] Vercel prod after env vars set: real submission → 200 with `fired.seniorsimple.ok=true`, `fired.retirement_rescue.ok=true`, `fired.slack.ok=true`
- [ ] Contact appears tagged in both SS + RR GHL locations, Slack message lands in #notifications-leads
- [ ] Existing three ebook routes still render 200
- [ ] EbookFunnel's modal submit still redirects to `/ebook/thank-you?dl=&name=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)