### PR TITLE
feat(ebook): serve PDFs from Supabase Storage, fix 404s

### DIFF
--- a/src/components/pages/EbookThankYou.tsx
+++ b/src/components/pages/EbookThankYou.tsx
@@ -12,31 +12,33 @@ type Offer = {
   files: DownloadFile[];
 };
 
+// Public Supabase Storage bucket, one PDF per book. Uploaded via storage.buckets
+// insert + REST /storage/v1/object POST. To add worksheets: upload to the same
+// bucket and reference `${EBOOK_ASSETS}/<slug>.pdf` here.
+const EBOOK_ASSETS =
+  'https://jqjftrlnyysqcwbbigpw.supabase.co/storage/v1/object/public/ebook-downloads';
+
 const OFFERS: Record<OfferKey, Offer> = {
   'annuity-dos-donts': {
     title: "Annuity Do's and Don'ts for Baby Boomers",
     headlineTemplate: 'Your guide is ready, {name}',
     files: [
-      { name: "Annuity Do's & Don'ts for Baby Boomers", href: '/downloads/ebook/annuity-dos-donts.pdf' },
-      { name: 'Retirement Income Gap Worksheet', href: '/downloads/ebook/income-gap-worksheet.pdf' },
+      { name: "Annuity Do's & Don'ts for Baby Boomers", href: `${EBOOK_ASSETS}/annuity-dos-donts.pdf` },
     ],
   },
   'simple-annuity-strategies': {
     title: 'Simple Annuity Strategies',
     headlineTemplate: 'Your guide is ready, {name}',
     files: [
-      { name: 'Simple Annuity Strategies', href: '/downloads/ebook/simple-annuity-strategies.pdf' },
-      { name: 'Income Maximizer Worksheet + Strategy Comparison Chart', href: '/downloads/ebook/income-maximizer-worksheet.pdf' },
+      { name: 'Simple Annuity Strategies', href: `${EBOOK_ASSETS}/simple-annuity-strategies.pdf` },
     ],
   },
   'retirement-made-simple': {
     title: 'Retirement Made Simple',
     headlineTemplate: 'Your free guides are ready, {name}',
     files: [
-      { name: "Annuity Do's & Don'ts for Baby Boomers", href: '/downloads/ebook/annuity-dos-donts.pdf' },
-      { name: 'Simple Annuity Strategies', href: '/downloads/ebook/simple-annuity-strategies.pdf' },
-      { name: 'Retirement Income Gap Worksheet', href: '/downloads/ebook/income-gap-worksheet.pdf' },
-      { name: 'Income Maximizer Worksheet', href: '/downloads/ebook/income-maximizer-worksheet.pdf' },
+      { name: "Annuity Do's & Don'ts for Baby Boomers", href: `${EBOOK_ASSETS}/annuity-dos-donts.pdf` },
+      { name: 'Simple Annuity Strategies', href: `${EBOOK_ASSETS}/simple-annuity-strategies.pdf` },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Fixes 404s on the ebook thank-you page for **Annuity Do's & Don'ts** and **Simple Annuity Strategies** by hosting the PDFs in a public Supabase Storage bucket instead of the repo's `public/downloads/ebook/` (which was only shipping one placeholder).
- Repoints `EbookThankYou.tsx` at the storage URLs.
- Drops the two worksheet cards (Retirement Income Gap Worksheet + Income Maximizer Worksheet) — we don't have those PDFs yet, and leaving them in was shipping guaranteed 404s. Add back when uploaded.

## Storage details
- **Project**: `jqjftrlnyysqcwbbigpw` (callready quiz)
- **Bucket**: `ebook-downloads` (public, 20MB file-size limit, `application/pdf` only)
- **Files uploaded**:
  - `annuity-dos-donts.pdf` (1.7MB)
  - `simple-annuity-strategies.pdf` (2.1MB)

Both verified 200 with correct `content-type` before the code change landed.

## Public URLs (also used in `EBOOK_ASSETS` constant)
```
https://jqjftrlnyysqcwbbigpw.supabase.co/storage/v1/object/public/ebook-downloads/annuity-dos-donts.pdf
https://jqjftrlnyysqcwbbigpw.supabase.co/storage/v1/object/public/ebook-downloads/simple-annuity-strategies.pdf
```

## Follow-ups (out of this PR)
- Worksheet PDFs (`Retirement Income Gap Worksheet`, `Income Maximizer Worksheet`) still not produced. Once you have them, upload to the same bucket and add back to the OFFERS map in `EbookThankYou.tsx` — one string per entry using the `EBOOK_ASSETS` constant.
- The Retirement Made Simple funnel value stack still promises the worksheets in the offer copy (`$99 value` line items). Not a code fix — copy decision. Options: keep the copy and ship worksheets, or trim the value stack.
- The old `public/downloads/ebook/annuity-dos-donts.pdf` (7MB PDF committed in PR #17) is now orphaned. Leaving in this PR to keep the diff focused; can `git rm` in a follow-up if you want to trim the repo.

## Test plan
- [ ] `/ebook/thank-you?dl=annuity-dos-donts&name=Test` → download card links to `https://jqjftrlnyysqcwbbigpw...annuity-dos-donts.pdf` and downloads a 1.7MB PDF
- [ ] `/ebook/thank-you?dl=simple-annuity-strategies&name=Test` → 2.1MB PDF
- [ ] `/ebook/thank-you?dl=retirement-made-simple&name=Test` → two cards, both download
- [ ] No card links return 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)