### PR TITLE
feat(ebook): feature-flag the value stack section

### DIFF
--- a/src/components/pages/EbookFunnel.tsx
+++ b/src/components/pages/EbookFunnel.tsx
@@ -122,6 +122,16 @@ const FUNNELS: Record<EbookFunnelKey, Funnel> = {
 
 const SUBMIT_ENDPOINT = '/api/ebook/submit';
 
+/**
+ * Value-stack section toggle.
+ * - Default state comes from NEXT_PUBLIC_SHOW_EBOOK_VALUE_STACK env var:
+ *   unset or "true" → shown, "false" → hidden.
+ * - Per-page override via ?stack=on|off query param (useful for internal
+ *   preview and ad-level A/B split tests without touching env).
+ */
+const SHOW_VALUE_STACK_DEFAULT =
+  process.env.NEXT_PUBLIC_SHOW_EBOOK_VALUE_STACK !== 'false';
+
 const THIRTY_THREE_FOOTNOTE =
   '*Illustrative and educational. “Up to 33%” refers to the combined impact that taxes, fees, and timing decisions can have on retirement income over time, based on the strategies discussed in this guide. Individual results vary and are not guaranteed.';
 
@@ -245,6 +255,14 @@ export default function EbookFunnel({ funnel }: { funnel: EbookFunnelKey }) {
   const [email, setEmail] = useState('');
   const [errEmail, setErrEmail] = useState('');
   const [submitting, setSubmitting] = useState(false);
+  const [showValueStack, setShowValueStack] = useState(SHOW_VALUE_STACK_DEFAULT);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const p = new URLSearchParams(window.location.search).get('stack');
+    if (p === 'off') setShowValueStack(false);
+    else if (p === 'on') setShowValueStack(true);
+  }, []);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -413,7 +431,8 @@ export default function EbookFunnel({ funnel }: { funnel: EbookFunnelKey }) {
           </div>
         </section>
 
-        {/* VALUE STACK */}
+        {/* VALUE STACK — hidden when NEXT_PUBLIC_SHOW_EBOOK_VALUE_STACK=false or ?stack=off */}
+        {showValueStack ? (
         <section className="ss-sec" style={{ background: '#F5F5F0', padding: '84px 24px' }}>
           <div className="ss-stack-wrap" style={{ maxWidth: 680, margin: '0 auto' }}>
             <h2 className="ss-h2" style={{ textAlign: 'center', fontSize: 29, fontWeight: 700, color: '#36596A', margin: '0 0 8px', textWrap: 'balance' as React.CSSProperties['textWrap'] }}>
@@ -452,6 +471,7 @@ export default function EbookFunnel({ funnel }: { funnel: EbookFunnelKey }) {
             </div>
           </div>
         </section>
+        ) : null}
 
         {/* PROOF + TRUST */}
         <section className="ss-sec" style={{ background: '#fff', padding: '84px 24px' }}>


### PR DESCRIPTION
## Summary
Adds a runtime toggle for the "Everything you get — free today" value stack across all three ebook funnels so we can measure impact on conversion without a redeploy.

- **`NEXT_PUBLIC_SHOW_EBOOK_VALUE_STACK` env var** — default shown. Set to `"false"` in Vercel env to hide site-wide.
- **`?stack=on|off` URL query param** — per-page override on top of the env default. Useful for internal preview and for splitting ad traffic to each variant without touching code.

## Behaviour matrix
| Env var | URL param | Value stack |
|---|---|---|
| unset or `"true"` | none | **shown** (current behaviour, no change) |
| `"false"` | none | hidden |
| any | `?stack=off` | hidden |
| any | `?stack=on` | shown |
| any | other `?stack=` values | falls back to env default |

## Applies to
All three funnels: `/ebook/annuity-dos-and-donts`, `/ebook/simple-annuity-strategies`, `/ebook/retirement-made-simple`.

## When hidden
Page flow: **Hero → Testimonials → Final CTA** (was: Hero → Value Stack → Testimonials → Final CTA). The mid-page CTA button that lived inside the value stack goes with it. Hero CTA, Final CTA, and sticky mobile bar still cover the primary conversion touchpoints.

## Verified in preview
- Default (no env var, no param) — value stack shown, 4 sections ✓
- `?stack=off` — hidden, 3 sections, flow goes Hero → What readers tell us → Final CTA ✓
- Works across all three funnels — verified on both `/ebook/retirement-made-simple?stack=off` and `/ebook/annuity-dos-and-donts?stack=off` ✓
- Screenshot of RMS with `?stack=off` attached below in verification comments

## How to run the test
1. Merge this PR — no behaviour change until you flip the flag
2. To test **without** value stack, either:
   - Flip Vercel env `NEXT_PUBLIC_SHOW_EBOOK_VALUE_STACK=false` and redeploy (site-wide)
   - Point half your ad traffic at `?stack=off` and the other half at `?stack=on` (per-ad split, no redeploy)
3. Compare conversion in Supabase `analytics_events` where `event_name='ebook_submit'` — group by `properties->>'page_url'` to bucket by variant

## Independent of PRs #23 and #24
Off main, doesn't touch the fields the other two PRs modify. Merge order doesn't matter.

## Test plan
- [ ] Default page loads still render the value stack (no config)
- [ ] `?stack=off` hides the "Everything you get — free today" section on all three routes
- [ ] `?stack=on` shows it even after setting env to `"false"` (env override)
- [ ] Hero + Testimonials + Final CTA all still render + are functional when stack is hidden
- [ ] Form submission from Hero or Final CTA still works in both states

🤖 Generated with [Claude Code](https://claude.com/claude-code)