### PR TITLE
feat(ebook): move trust badge above the book graphic

### DIFF
--- a/src/components/pages/EbookFunnel.tsx
+++ b/src/components/pages/EbookFunnel.tsx
@@ -402,15 +402,7 @@ export default function EbookFunnel({ funnel }: { funnel: EbookFunnelKey }) {
         <section className="ss-hero" style={{ background: '#36596A', backgroundImage: 'radial-gradient(120% 90% at 85% 10%,#3f6678 0%,#36596A 55%,#2f4e5d 100%)', color: '#fff', padding: '64px 24px 76px' }}>
           <div style={{ maxWidth: 1180, margin: '0 auto' }} className="ss-hero-grid">
             <div>
-              <div style={{ display: 'flex', justifyContent: 'center' }}>
-                <span style={{ display: 'inline-flex', alignItems: 'center', gap: 9, background: '#E4CDA1', color: '#33404a', fontSize: 13, fontWeight: 700, letterSpacing: '.02em', padding: '8px 17px', borderRadius: 999 }}>
-                  <span style={{ display: 'inline-flex', gap: 1 }}>
-                    <Star /><Star /><Star /><Star /><Star />
-                  </span>
-                  Trusted by over 23,000 seniors
-                </span>
-              </div>
-              <h1 className="ss-h1" style={{ fontFamily: 'Georgia, "Times New Roman", ui-serif, serif', fontWeight: 600, fontSize: 48, lineHeight: 1.06, margin: '22px 0 0', letterSpacing: '-.01em', textWrap: 'balance' as React.CSSProperties['textWrap'] }}>
+              <h1 className="ss-h1" style={{ fontFamily: 'Georgia, "Times New Roman", ui-serif, serif', fontWeight: 600, fontSize: 48, lineHeight: 1.06, margin: 0, letterSpacing: '-.01em', textWrap: 'balance' as React.CSSProperties['textWrap'] }}>
                 {f.h1a}
                 {f.h1em ? (
                   <span style={{ color: '#E4CDA1', textDecoration: 'underline', textDecorationColor: 'rgba(228,205,161,.55)', textDecorationThickness: '4px', textUnderlineOffset: '8px' }}>
@@ -456,7 +448,13 @@ export default function EbookFunnel({ funnel }: { funnel: EbookFunnelKey }) {
               </div>
             </div>
 
-            <div className="ss-hero-media" style={{ display: 'flex', flexDirection: 'column', gap: 26, alignItems: 'center', justifyContent: 'center' }}>
+            <div className="ss-hero-media" style={{ display: 'flex', flexDirection: 'column', gap: 20, alignItems: 'center', justifyContent: 'center' }}>
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 9, background: '#E4CDA1', color: '#33404a', fontSize: 13, fontWeight: 700, letterSpacing: '.02em', padding: '8px 17px', borderRadius: 999 }}>
+                <span style={{ display: 'inline-flex', gap: 1 }}>
+                  <Star /><Star /><Star /><Star /><Star />
+                </span>
+                Trusted by over 23,000 seniors
+              </span>
               {f.isKit ? (
                 <KitBooks />
               ) : f.coverFlat ? (


### PR DESCRIPTION
## Summary
Moves the "★★★★★ Trusted by over 23,000 seniors" badge from the top of the left text column to inside the right media column, directly above the book graphic. Social proof now visually anchors to the product artwork instead of interrupting the copy sequence.

Applies to all three funnels — the single-paperback layouts (Annuity Do's & Don'ts, Simple Annuity Strategies) and the fanned kit (Retirement Made Simple) both get the badge on top.

## Layout after
**Left column**: H1 → subhead → subtext (if set) → bullets (if set) → CTA
**Right column**: badge → book graphic

Removed the H1's `margin: '22px 0 0'` since the badge no longer precedes it — the column now starts flush at the H1.

## Mobile
No stack order change: `ss-hero-media` already had `order: -1` on ≤640px, so the media column (now including the badge) still stacks first on mobile — same "badge above the fold" pattern as before.

## Verified in preview
- `/ebook/retirement-made-simple` — badge sits above the two fanned paperbacks ✓
- `/ebook/annuity-dos-and-donts` — badge sits above the single 3D paperback ✓
- Screenshots of both attached to the branch commits

## Test plan
- [ ] All three funnels render the badge in the right column above the book graphic
- [ ] H1 no longer has a gap above it in the left column
- [ ] Mobile: badge + book stack first, text column follows below

🤖 Generated with [Claude Code](https://claude.com/claude-code)