### PR TITLE
feat(ebook/rms): heroSubtext refers to Advanced Annuity Strategies

### DIFF
--- a/src/components/pages/EbookFunnel.tsx
+++ b/src/components/pages/EbookFunnel.tsx
@@ -105,7 +105,7 @@ const FUNNELS: Record<EbookFunnelKey, Funnel> = {
     subHi: 'Up to 33% More Guaranteed Income',
     subB: ' For Life',
     heroSubtext:
-      "Most advisors will never show you this strategy — because most of them don't know it exists. Inside Simple Annuity Strategies, you'll discover the exact laddering method that pulls every last dollar of guaranteed lifetime income out of the savings you already have. No new risk. No market exposure. Just more income, contractually guaranteed for as long as you live.",
+      "Most advisors will never show you this strategy — because most of them don't know it exists. Inside Advanced Annuity Strategies, you'll discover the exact laddering method that pulls every last dollar of guaranteed lifetime income out of the savings you already have. No new risk. No market exposure. Just more income, contractually guaranteed for as long as you live.",
     bullets: [],
     heroCta: 'Get the Free Guides',
     isKit: true,


### PR DESCRIPTION
Aligns the subtext with the new cover art from #29 — the front book on the fanned pair is titled "Advanced Annuity Strategies", so the paragraph now reads:

> Most advisors will never show you this strategy — because most of them don't know it exists. **Inside Advanced Annuity Strategies**, you'll discover the exact laddering method that pulls every last dollar of guaranteed lifetime income out of the savings you already have. No new risk. No market exposure. Just more income, contractually guaranteed for as long as you live.

One-word swap. Retirement Made Simple funnel only. Verified in dev preview: 1 match for "Advanced Annuity Strategies" in the subtext, 0 for "Simple Annuity Strategies".

## Not touched in this PR
- The `simple-annuity-strategies` sibling funnel — its `ebookTitle`, URL slug, `stack` line items, and `finalTitle` still say "Simple Annuity Strategies" everywhere. Flag if you want the rename to propagate.
- The RMS `stack` entry "Simple Annuity Strategies guide" also still reads that way. Same flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)