### PR TITLE
fix(articles): wire up newsletter capture — plug the 0.05% leak

### DIFF
--- a/src/app/articles/[slug]/page.tsx
+++ b/src/app/articles/[slug]/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import Image from 'next/image'
 import InterstitialCTABanner from '@/components/articles/InterstitialCTABanner'
 import ScrollRevealedCallButton from '@/components/articles/ScrollRevealedCallButton'
+import NewsletterCaptureCTA from '@/components/articles/NewsletterCaptureCTA'
 import MedicareCostCalculator from '@/components/calculators/MedicareCostCalculator'
 
 interface ArticlePageProps {
@@ -316,30 +317,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         </section>
       )}
 
-      {/* Newsletter CTA */}
-      <section className="py-16 px-6" style={{ background: 'linear-gradient(135deg, #36596A 0%, #82A6B1 100%)' }}>
-        <div className="max-w-4xl mx-auto text-center">
-          <h2 className="text-3xl font-serif font-semibold text-white mb-4">
-            Stay Informed About Retirement Planning
-          </h2>
-          <p className="text-xl text-white mb-8 opacity-90">
-            Get expert insights and practical advice delivered to your inbox weekly.
-          </p>
-          <div className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto">
-            <input 
-              type="email" 
-              placeholder="Enter your email" 
-              className="flex-1 px-4 py-3 rounded-lg border-0 text-gray-900"
-            />
-            <button className="bg-white text-[#36596A] px-8 py-3 rounded-lg font-medium hover:bg-gray-100 transition-colors">
-              Subscribe
-            </button>
-          </div>
-          <p className="text-sm text-white mt-4 opacity-80">
-            Join 50,000+ seniors making informed retirement decisions.
-          </p>
-        </div>
-      </section>
+      <NewsletterCaptureCTA slug={slug} category={article.category_details?.name ?? null} />
     </div>
   )
 }

--- a/src/components/articles/NewsletterCaptureCTA.tsx
+++ b/src/components/articles/NewsletterCaptureCTA.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useState } from 'react'
+
+interface NewsletterCaptureCTAProps {
+  slug: string
+  category?: string | null
+}
+
+// Central Publishare subscribe endpoint (public, verify_jwt=false, CORS open).
+// Handles dedup, honeypot, IP rate limit, GHL sync.
+const SUBSCRIBE_ENDPOINT =
+  'https://vpysqshhafthuxvokwqj.supabase.co/functions/v1/subscribe'
+
+export default function NewsletterCaptureCTA({ slug, category }: NewsletterCaptureCTAProps) {
+  const [email, setEmail] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [honeypot, setHoneypot] = useState('') // Bot trap — real users leave empty
+  const [status, setStatus] = useState<'idle' | 'submitting' | 'success' | 'error'>('idle')
+  const [message, setMessage] = useState<string>('')
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (status === 'submitting') return
+
+    const trimmed = email.trim().toLowerCase()
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setStatus('error')
+      setMessage('Please enter a valid email address.')
+      return
+    }
+
+    setStatus('submitting')
+    setMessage('')
+
+    try {
+      const res = await fetch(SUBSCRIBE_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email: trimmed,
+          site_id: 'seniorsimple',
+          first_name: firstName.trim() || null,
+          source: 'article',
+          source_detail: `article:${slug}`,
+          tags: [
+            'article_cta',
+            'medicare_planning_guide',
+            ...(category ? [`category:${category.toLowerCase().replace(/\s+/g, '_')}`] : []),
+          ],
+          website: honeypot,
+        }),
+      })
+      const data = await res.json().catch(() => ({}))
+
+      if (!res.ok) {
+        setStatus('error')
+        setMessage(data?.error || 'Something went wrong. Please try again.')
+        return
+      }
+
+      setStatus('success')
+      setMessage(
+        data?.reactivated
+          ? "Welcome back! You're resubscribed."
+          : data?.is_new === false
+          ? "You're already on the list — thanks!"
+          : "You're in. Check your inbox for the 2026 Medicare Planning Guide.",
+      )
+    } catch {
+      setStatus('error')
+      setMessage('Network error. Please try again.')
+    }
+  }
+
+  if (status === 'success') {
+    return (
+      <section
+        className="py-16 px-6"
+        style={{ background: 'linear-gradient(135deg, #36596A 0%, #82A6B1 100%)' }}
+      >
+        <div className="max-w-4xl mx-auto text-center">
+          <h2 className="text-3xl font-serif font-semibold text-white mb-4">Thanks!</h2>
+          <p className="text-xl text-white opacity-90">{message}</p>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section
+      className="py-16 px-6"
+      style={{ background: 'linear-gradient(135deg, #36596A 0%, #82A6B1 100%)' }}
+    >
+      <div className="max-w-4xl mx-auto text-center">
+        <h2 className="text-3xl font-serif font-semibold text-white mb-4">
+          Free 2026 Medicare Planning Guide
+        </h2>
+        <p className="text-xl text-white mb-8 opacity-90">
+          Get the plain-English guide to Medicare, Medigap, and prescription costs —
+          plus weekly expert tips for retirees. No spam, unsubscribe anytime.
+        </p>
+
+        <form
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-4 max-w-md mx-auto"
+          noValidate
+        >
+          <input
+            type="text"
+            placeholder="First name (optional)"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            autoComplete="given-name"
+            className="w-full px-4 py-3 rounded-lg border-0 text-gray-900"
+            disabled={status === 'submitting'}
+          />
+
+          <div className="flex flex-col sm:flex-row gap-4">
+            <input
+              type="email"
+              placeholder="Enter your email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              autoComplete="email"
+              required
+              aria-label="Email address"
+              className="flex-1 px-4 py-3 rounded-lg border-0 text-gray-900"
+              disabled={status === 'submitting'}
+            />
+            <button
+              type="submit"
+              disabled={status === 'submitting'}
+              className="bg-white text-[#36596A] px-8 py-3 rounded-lg font-medium hover:bg-gray-100 transition-colors disabled:opacity-70 disabled:cursor-not-allowed"
+            >
+              {status === 'submitting' ? 'Sending…' : 'Send Me the Guide'}
+            </button>
+          </div>
+
+          {/* Honeypot — hidden from real users, filled by naive bots */}
+          <input
+            type="text"
+            name="website"
+            value={honeypot}
+            onChange={(e) => setHoneypot(e.target.value)}
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              left: '-10000px',
+              width: 1,
+              height: 1,
+              opacity: 0,
+            }}
+          />
+        </form>
+
+        {status === 'error' && (
+          <p className="text-sm text-white mt-4 opacity-90" role="alert">
+            {message}
+          </p>
+        )}
+
+        <p className="text-sm text-white mt-4 opacity-80">
+          Join 50,000+ seniors making informed retirement decisions.
+        </p>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- **Replaces the dead newsletter CTA at the bottom of `/articles/[slug]`** — the existing block had a bare `<input>` + `<button>` with no state, no handler, no network call. That's the entire seniorsimple capture leak.
- **New `NewsletterCaptureCTA` client component** posts to Publishare's `subscribe` edge function (`site_id=seniorsimple`, `source=article`, `source_detail=article:<slug>`, tags include `article_cta`, `medicare_planning_guide`, and `category:<name>`).
- **Framing**: "Free 2026 Medicare Planning Guide" — mirrors the pattern that actually converted on `/free-burial-life-insurance-guide` (the one working page).

## Why now
Over the last 28 days seniorsimple got **1,850 organic clicks** across its top 20 articles (top page alone = 392 clicks) but produced **1 newsletter subscriber**. Capture rate: **0.05%**. moneysimple's inline quiz CTA runs 2–3%. Even a naive 1.5% would be ~28 subs/month from current traffic — the leak has been sitting in production because the CTA JSX rendered fine and nobody noticed the button did nothing.

## What's wired
- Subscribe endpoint (`https://vpysqshhafthuxvokwqj.supabase.co/functions/v1/subscribe`) already handles: dedup by `(email, site_id)`, honeypot, IP rate limit (10/hr), GHL sync trigger, reactivation of previously-unsubscribed emails.
- Rows land in `newsletter_subscribers` so the `v_subscriber_funnel` view + capture-rate line in `health-digest` pick it up automatically.

## Test plan
- [ ] Vercel preview: visit any `/articles/<slug>` page, scroll to bottom, submit the form, confirm success message.
- [ ] Confirm row appears in `newsletter_subscribers` with `site_id='seniorsimple'`, `source='article'`, `source_detail='article:<slug>'`, `tags` includes `article_cta`.
- [ ] Confirm honeypot doesn't block real submissions (`website` field is offscreen and empty by default).
- [ ] Confirm rate limit (10 submissions in one hour from same IP → 429 on the 11th) does not affect single-user flow.
- [ ] After merge to `main`: watch `v_subscriber_funnel` for seniorsimple over 48h; expect the leak-rate line in health-digest to start moving.

## Follow-ups (not this PR)
- Article template also has a `<ScrollRevealedCallButton>` and `<InterstitialCTABanner>` — both are phone-only. Consider adding an in-content email variant for readers who won't call.
- If we want to A/B test framing (Guide vs Quiz), the component takes 5 lines to fork — happy to open a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)