### PR TITLE
feat(ebook): rename Simple → Advanced Annuity Strategies (full sweep)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -34,6 +34,11 @@ const nextConfig: NextConfig = {
         destination: '/ebook/retirement-made-simple',
         permanent: true,
       },
+      {
+        source: '/ebook/simple-annuity-strategies',
+        destination: '/ebook/advanced-annuity-strategies',
+        permanent: true,
+      },
     ];
   },
   // Rewrite rules for IndexNow key file

--- a/src/app/api/ebook/submit/route.ts
+++ b/src/app/api/ebook/submit/route.ts
@@ -6,7 +6,7 @@ export const dynamic = 'force-dynamic';
 
 const EBOOK_FUNNELS = {
   'annuity-dos-donts': "Annuity Do's and Don'ts for Baby Boomers",
-  'simple-annuity-strategies': 'Simple Annuity Strategies',
+  'advanced-annuity-strategies': 'Advanced Annuity Strategies',
   'retirement-made-simple': 'Retirement Made Simple',
 } as const;
 type EbookFunnelKey = keyof typeof EBOOK_FUNNELS;

--- a/src/app/ebook/advanced-annuity-strategies/page.tsx
+++ b/src/app/ebook/advanced-annuity-strategies/page.tsx
@@ -2,11 +2,11 @@ import type { Metadata } from 'next';
 import EbookFunnel from '../../../components/pages/EbookFunnel';
 
 export const metadata: Metadata = {
-  title: 'Simple Annuity Strategies: Get More From the Same Retirement Dollars | SeniorSimple',
+  title: 'Advanced Annuity Strategies: Get More From the Same Retirement Dollars | SeniorSimple',
   description:
     'The newer annuity strategies that may help you keep up to 33% more total income — without more market risk. Free guide.',
 };
 
-export default function SimpleAnnuityStrategiesPage() {
-  return <EbookFunnel funnel="simple-annuity-strategies" />;
+export default function AdvancedAnnuityStrategiesPage() {
+  return <EbookFunnel funnel="advanced-annuity-strategies" />;
 }

--- a/src/components/pages/EbookFunnel.tsx
+++ b/src/components/pages/EbookFunnel.tsx
@@ -5,7 +5,7 @@ import { useStandaloneLayout } from '../../hooks/useFunnelFooter';
 
 export type EbookFunnelKey =
   | 'annuity-dos-donts'
-  | 'simple-annuity-strategies'
+  | 'advanced-annuity-strategies'
   | 'retirement-made-simple';
 
 type Bullet = { lead: string; text: string };
@@ -69,9 +69,9 @@ const FUNNELS: Record<EbookFunnelKey, Funnel> = {
     finalMicro: 'Instant download — check your inbox.',
     ebookTitle: "Annuity Do's and Don'ts for Baby Boomers",
   },
-  'simple-annuity-strategies': {
+  'advanced-annuity-strategies': {
     h1a: '',
-    h1em: 'Simple',
+    h1em: 'Advanced',
     h1b: ' Annuity Strategies: How to Get More From the Same Retirement Dollars',
     subA: 'The newer annuity strategies that may help you keep ',
     subHi: 'up to 33% more total income',
@@ -83,19 +83,19 @@ const FUNNELS: Record<EbookFunnelKey, Funnel> = {
     ],
     heroCta: 'Reveal the Strategies',
     coverFlat: '/images/ebook/cover-strategies-flat.png',
-    coverAlt: 'Simple Annuity Strategies — free guide cover',
+    coverAlt: 'Advanced Annuity Strategies — free guide cover',
     stack: [
-      { name: 'Simple Annuity Strategies guide', desc: 'get more from the same dollars', value: '$49 value' },
+      { name: 'Advanced Annuity Strategies guide', desc: 'get more from the same dollars', value: '$49 value' },
       { name: 'Income Maximizer Worksheet', desc: 'model your optimized monthly income', value: '$99 value' },
       { name: 'Strategy Comparison Chart', desc: 'see default vs. optimized side by side', value: '$39 value' },
       { name: '15-minute Income Strategy Call', desc: 'with a licensed professional — no obligation, ever', value: '$200 value' },
     ],
     stackTotal: '$387',
-    finalTitle: 'Get the Free Simple Strategies Guide',
+    finalTitle: 'Get the Free Advanced Strategies Guide',
     finalSub: "The modern moves most agents don't lead with — yours to read in the next two minutes.",
     finalCta: 'Reveal the Strategies',
     finalMicro: 'Instant download — check your inbox.',
-    ebookTitle: 'Simple Annuity Strategies',
+    ebookTitle: 'Advanced Annuity Strategies',
   },
   'retirement-made-simple': {
     h1a: 'The Little-Known Annuity “',
@@ -105,7 +105,7 @@ const FUNNELS: Record<EbookFunnelKey, Funnel> = {
     subHi: 'Up to 33% More Guaranteed Income',
     subB: ' For Life',
     heroSubtext:
-      "Most advisors will never show you this strategy — because most of them don't know it exists. Inside Simple Annuity Strategies, you'll discover the exact laddering method that pulls every last dollar of guaranteed lifetime income out of the savings you already have. No new risk. No market exposure. Just more income, contractually guaranteed for as long as you live.",
+      "Most advisors will never show you this strategy — because most of them don't know it exists. Inside Advanced Annuity Strategies, you'll discover the exact laddering method that pulls every last dollar of guaranteed lifetime income out of the savings you already have. No new risk. No market exposure. Just more income, contractually guaranteed for as long as you live.",
     bullets: [],
     heroCta: 'Get the Free Guides',
     isKit: true,
@@ -113,7 +113,7 @@ const FUNNELS: Record<EbookFunnelKey, Funnel> = {
     coverAlt: 'Retirement Made Simple — both free guides, fanned together',
     stack: [
       { name: "Annuity Do's & Don'ts guide", desc: 'stop the leaks before they start', value: '$49 value' },
-      { name: 'Simple Annuity Strategies guide', desc: 'get more from the same dollars', value: '$49 value' },
+      { name: 'Advanced Annuity Strategies guide', desc: 'get more from the same dollars', value: '$49 value' },
       { name: 'Retirement Income Gap Worksheet', desc: 'see your real monthly shortfall', value: '$99 value' },
       { name: 'Income Maximizer Worksheet', desc: 'model your optimized income', value: '$99 value' },
       { name: "“10 Questions” card + 1-page audit", desc: 'stay in control of every conversation', value: '$39 value' },
@@ -254,14 +254,14 @@ function KitBooks() {
             <div style={{ position: 'absolute', top: 0, left: 0, width: 14, height: '100%', background: 'linear-gradient(90deg,rgba(0,0,0,.24),rgba(0,0,0,0))' }} />
           </div>
         </div>
-        {/* FRONT: Simple Annuity Strategies */}
+        {/* FRONT: Advanced Annuity Strategies */}
         <div style={{ position: 'absolute', left: 4, top: 0, zIndex: 2, width: 272, height: 356, transformStyle: 'preserve-3d', transform: 'perspective(2400px) rotateY(-22deg) rotateX(4deg)' }}>
           <div style={{ position: 'absolute', top: 0, left: 0, width: 272, height: 34, transform: 'translateY(-17px) rotateX(90deg)', background: TOP_EDGES_H }} />
           <div style={{ position: 'absolute', top: 0, left: 0, width: 34, height: 356, transform: 'translateX(255px) rotateY(90deg)', background: SIDE_EDGES_V }} />
           <div style={{ position: 'absolute', top: 0, left: 0, width: 34, height: 356, transform: 'translateX(-17px) rotateY(-90deg)', background: SPINE_GRADIENT, borderRight: '2px solid rgba(228,205,161,.5)' }} />
           <div style={{ position: 'absolute', top: 0, left: 0, width: 272, height: 356, transform: 'translateZ(17px)', borderRadius: '2px 5px 5px 2px', overflow: 'hidden', boxShadow: 'inset 6px 0 14px rgba(0,0,0,.16), inset 0 0 0 1px rgba(0,0,0,.05)' }}>
             {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/images/ebook/cover-strategies-flat.png" alt="Simple Annuity Strategies guide cover" decoding="async" style={{ width: '100%', height: '100%', display: 'block', objectFit: 'cover' }} />
+            <img src="/images/ebook/cover-strategies-flat.png" alt="Advanced Annuity Strategies guide cover" decoding="async" style={{ width: '100%', height: '100%', display: 'block', objectFit: 'cover' }} />
             <div style={{ position: 'absolute', top: 0, left: 0, width: 14, height: '100%', background: 'linear-gradient(90deg,rgba(0,0,0,.22),rgba(0,0,0,0))' }} />
             <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(105deg,rgba(255,255,255,.16) 0%,rgba(255,255,255,0) 34%)', pointerEvents: 'none' }} />
           </div>
@@ -589,7 +589,7 @@ export default function EbookFunnel({ funnel }: { funnel: EbookFunnelKey }) {
                 <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: '.06em', textTransform: 'uppercase', color: '#E4CDA1', marginBottom: 14 }}>Guides</div>
                 <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 9, fontSize: 14 }}>
                   <li>Annuity Do&apos;s &amp; Don&apos;ts</li>
-                  <li>Simple Annuity Strategies</li>
+                  <li>Advanced Annuity Strategies</li>
                   <li>Retirement Made Simple</li>
                 </ul>
               </div>

--- a/src/components/pages/EbookThankYou.tsx
+++ b/src/components/pages/EbookThankYou.tsx
@@ -3,7 +3,7 @@
 import { useSearchParams } from 'next/navigation';
 import { useStandaloneLayout } from '../../hooks/useFunnelFooter';
 
-type OfferKey = 'annuity-dos-donts' | 'simple-annuity-strategies' | 'retirement-made-simple';
+type OfferKey = 'annuity-dos-donts' | 'advanced-annuity-strategies' | 'retirement-made-simple';
 
 type DownloadFile = { name: string; href: string };
 type Offer = {
@@ -26,11 +26,11 @@ const OFFERS: Record<OfferKey, Offer> = {
       { name: "Annuity Do's & Don'ts for Baby Boomers", href: `${EBOOK_ASSETS}/annuity-dos-donts.pdf` },
     ],
   },
-  'simple-annuity-strategies': {
-    title: 'Simple Annuity Strategies',
+  'advanced-annuity-strategies': {
+    title: 'Advanced Annuity Strategies',
     headlineTemplate: 'Your guide is ready, {name}',
     files: [
-      { name: 'Simple Annuity Strategies', href: `${EBOOK_ASSETS}/simple-annuity-strategies.pdf` },
+      { name: 'Advanced Annuity Strategies', href: `${EBOOK_ASSETS}/advanced-annuity-strategies.pdf` },
     ],
   },
   'retirement-made-simple': {
@@ -38,7 +38,7 @@ const OFFERS: Record<OfferKey, Offer> = {
     headlineTemplate: 'Your free guides are ready, {name}',
     files: [
       { name: "Annuity Do's & Don'ts for Baby Boomers", href: `${EBOOK_ASSETS}/annuity-dos-donts.pdf` },
-      { name: 'Simple Annuity Strategies', href: `${EBOOK_ASSETS}/simple-annuity-strategies.pdf` },
+      { name: 'Advanced Annuity Strategies', href: `${EBOOK_ASSETS}/advanced-annuity-strategies.pdf` },
     ],
   },
 };
@@ -274,7 +274,7 @@ export default function EbookThankYou() {
                 <div style={{ fontSize: 13, fontWeight: 700, letterSpacing: '.06em', textTransform: 'uppercase', color: '#E4CDA1', marginBottom: 14 }}>Guides</div>
                 <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 9, fontSize: 14 }}>
                   <li>Annuity Do&apos;s &amp; Don&apos;ts</li>
-                  <li>Simple Annuity Strategies</li>
+                  <li>Advanced Annuity Strategies</li>
                   <li>Retirement Made Simple</li>
                 </ul>
               </div>


### PR DESCRIPTION
Renames the strategies funnel end-to-end to match the new cover art shipped in #29. Supersedes #30 (closed) — that one-word RMS subtext change is included here.

## Code
- **`EbookFunnel.tsx`** — FUNNELS key `simple-annuity-strategies` → `advanced-…`; `h1em` "Simple" → "Advanced"; `ebookTitle`, `coverAlt`, `finalTitle`, footer link, RMS stack line item, RMS `heroSubtext` all updated. Comment + alt inside the fallback `<KitBooks />` component also updated for consistency.
- **Route directory** — `git mv src/app/ebook/simple-annuity-strategies → advanced-annuity-strategies`. Metadata title + component name updated.
- **`EbookThankYou.tsx`** — `OfferKey` type + `OFFERS` map key updated; PDF URL points at new filename; RMS bundle offer references updated; footer link updated.
- **`/api/ebook/submit/route.ts`** — `EBOOK_FUNNELS` map key + display value.
- **`next.config.ts`** — added 308 permanent redirect: `/ebook/simple-annuity-strategies` → `/ebook/advanced-annuity-strategies`. The existing retirement-rescue-kit redirect stays.

## Supabase Storage
Copied `simple-annuity-strategies.pdf` → `advanced-annuity-strategies.pdf` in the `ebook-downloads` bucket (2.1MB, matches source). Old filename left in place for the 308 continuity window.

## Verified in local preview
- `/ebook/advanced-annuity-strategies` — H1 `Advanced Annuity Strategies…`, 0 "Simple" refs, 3 "Advanced" refs
- `/ebook/simple-annuity-strategies` — 308 → `/ebook/advanced-annuity-strategies`
- `/ebook/retirement-made-simple` — `Inside Advanced Annuity Strategies…` subtext, "Advanced Annuity Strategies guide" stack line, 0 "Simple" refs, 3 "Advanced" refs
- `/ebook/annuity-dos-and-donts` — untouched, 200

## ⚠️ Known follow-ups (not in this PR)
- **`public/images/ebook/cover-strategies-flat.png` still visually reads "Simple Annuity Strategies"** on the book cover. RMS uses the kit graphic and is fine — but the standalone `/ebook/advanced-annuity-strategies` funnel will render a book cover that says "Simple" until a new flat PNG is supplied.
- **New file spotted**: `public/images/ebook/Ebook - Advanced Annuity Strategies-print.pdf` (untracked, not in this PR). If this is the reissued ebook, I can upload it to Supabase Storage as `advanced-annuity-strategies.pdf` (overwriting the old-interior copy) in a follow-up.
- **Analytics + GHL data**: existing rows in Supabase `contacts.metadata.ebook_funnel` + `analytics_events.properties.funnel_type` still say `simple-annuity-strategies` (unchanged — no backfill). New submissions after deploy will be `advanced-annuity-strategies`. Any GHL workflow branching on `funnel_type` needs to accept **both** values.
- **Meta ads / GTM tags** pointing at the old URL keep working via the 308 but ad reports will show both slugs.

## Test plan
- [ ] `/ebook/advanced-annuity-strategies` — new URL renders, H1 shows "Advanced" in gold
- [ ] `/ebook/simple-annuity-strategies` — returns 308 → new URL
- [ ] `/ebook/retirement-made-simple` — subtext + stack + finalTitle all say Advanced
- [ ] Submit form on any funnel — POST body carries new `funnel_type`; thank-you page download link is `.../advanced-annuity-strategies.pdf` (200 verified)
- [ ] `/ebook/annuity-dos-and-donts` and `/ebook/thank-you` untouched
- [ ] Grep confirms no `Simple Annuity Strategies` / `simple-annuity-strategies` in `src/` (only the intentional redirect source in `next.config.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)