### PR TITLE
feat(capture): Medicare email-capture units + resource LPs

### DIFF
--- a/public/lead-magnets/README.md
+++ b/public/lead-magnets/README.md
@@ -1,0 +1,15 @@
+# Medicare Capture Lead Magnets — PLACEHOLDERS
+
+These files are referenced by `src/lib/medicare-capture-config.ts` (`MAGNETS`).
+Drop the finished PDFs in this directory before launch. Filenames MUST match:
+
+| magnetId       | File                                    | Referenced by                                     |
+| -------------- | --------------------------------------- | ------------------------------------------------- |
+| `decision-kit` | `medicare-decision-kit-2026.pdf`        | glp1, medigap, advantage, part-d pages            |
+| `tool-result`  | `medicare-estimate-template.pdf`        | Cost calculator, comparison tool                  |
+| `starter-guide`| `medicare-starter-guide.pdf`            | Medicaid vs Medicare, open-enrollment pages       |
+
+Copy source: `3_Medicare_Lead_Magnets.md` (Keenan is preparing).
+
+Until the PDFs are dropped in, the download button in the capture unit success
+state will 404 — that's OK for a staging demo. Do NOT ship to prod without them.

--- a/public/lead-magnets/covers/medicare-decision-kit-2026.svg
+++ b/public/lead-magnets/covers/medicare-decision-kit-2026.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 520" role="img" aria-label="2026 Medicare Decision Kit placeholder cover">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#36596A"/>
+      <stop offset="100%" stop-color="#243c47"/>
+    </linearGradient>
+    <linearGradient id="spine" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#000" stop-opacity="0.25"/>
+      <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="520" fill="url(#bg)"/>
+  <rect x="0" y="0" width="18" height="520" fill="url(#spine)"/>
+  <rect x="28" y="28" width="344" height="464" fill="none" stroke="#E4CDA1" stroke-width="1.5" opacity="0.5"/>
+  <text x="200" y="90" fill="#E4CDA1" font-family="Georgia, serif" font-size="18" font-style="italic" text-anchor="middle" letter-spacing="4">SENIORSIMPLE</text>
+  <line x1="130" y1="110" x2="270" y2="110" stroke="#E4CDA1" stroke-width="1" opacity="0.7"/>
+  <text x="200" y="200" fill="#F5F5F0" font-family="Georgia, serif" font-size="44" font-weight="700" text-anchor="middle">2026</text>
+  <text x="200" y="260" fill="#F5F5F0" font-family="Georgia, serif" font-size="32" font-weight="600" text-anchor="middle">Medicare</text>
+  <text x="200" y="300" fill="#F5F5F0" font-family="Georgia, serif" font-size="32" font-weight="600" text-anchor="middle">Decision Kit</text>
+  <rect x="120" y="330" width="160" height="1" fill="#E4CDA1"/>
+  <text x="200" y="365" fill="#E4CDA1" font-family="Georgia, serif" font-size="14" text-anchor="middle" letter-spacing="1">A plain-English guide</text>
+  <text x="200" y="390" fill="#E4CDA1" font-family="Georgia, serif" font-size="14" text-anchor="middle" letter-spacing="1">for choosing coverage</text>
+  <g transform="translate(200 445)" opacity="0.85">
+    <circle r="24" fill="none" stroke="#E4CDA1" stroke-width="1.5"/>
+    <path d="M -10 0 L -3 8 L 12 -8" stroke="#E4CDA1" stroke-width="2.5" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/public/lead-magnets/covers/medicare-estimate.svg
+++ b/public/lead-magnets/covers/medicare-estimate.svg
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 520" role="img" aria-label="Your Medicare Estimate placeholder cover">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#F5F5F0"/>
+      <stop offset="100%" stop-color="#EDECE3"/>
+    </linearGradient>
+    <linearGradient id="spine" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#000" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="520" fill="url(#bg)"/>
+  <rect x="0" y="0" width="18" height="520" fill="url(#spine)"/>
+  <rect x="28" y="28" width="344" height="464" fill="none" stroke="#36596A" stroke-width="1.5" opacity="0.35"/>
+  <text x="200" y="90" fill="#36596A" font-family="Georgia, serif" font-size="18" font-style="italic" text-anchor="middle" letter-spacing="4">SENIORSIMPLE</text>
+  <line x1="130" y1="110" x2="270" y2="110" stroke="#36596A" stroke-width="1" opacity="0.5"/>
+  <text x="200" y="180" fill="#36596A" font-family="Georgia, serif" font-size="30" font-weight="600" text-anchor="middle">Your Medicare</text>
+  <text x="200" y="220" fill="#36596A" font-family="Georgia, serif" font-size="30" font-weight="600" text-anchor="middle">Estimate</text>
+  <rect x="70" y="255" width="260" height="150" fill="#ffffff" stroke="#36596A" stroke-width="1" opacity="0.85"/>
+  <text x="90" y="285" fill="#36596A" font-family="Georgia, serif" font-size="13" opacity="0.75">Monthly premium</text>
+  <text x="310" y="285" fill="#36596A" font-family="Georgia, serif" font-size="14" font-weight="700" text-anchor="end">$ ___</text>
+  <line x1="80" y1="298" x2="320" y2="298" stroke="#36596A" stroke-width="0.5" opacity="0.3"/>
+  <text x="90" y="325" fill="#36596A" font-family="Georgia, serif" font-size="13" opacity="0.75">Annual out-of-pocket</text>
+  <text x="310" y="325" fill="#36596A" font-family="Georgia, serif" font-size="14" font-weight="700" text-anchor="end">$ ___</text>
+  <line x1="80" y1="338" x2="320" y2="338" stroke="#36596A" stroke-width="0.5" opacity="0.3"/>
+  <text x="90" y="365" fill="#36596A" font-family="Georgia, serif" font-size="13" opacity="0.75">Est. total 2026</text>
+  <text x="310" y="365" fill="#E4CDA1" font-family="Georgia, serif" font-size="18" font-weight="700" text-anchor="end">$ ___</text>
+  <line x1="80" y1="378" x2="320" y2="378" stroke="#36596A" stroke-width="0.5" opacity="0.3"/>
+  <text x="200" y="445" fill="#36596A" font-family="Georgia, serif" font-size="13" text-anchor="middle" letter-spacing="1" opacity="0.75">Save. Print. Compare.</text>
+</svg>

--- a/public/lead-magnets/covers/medicare-starter-guide.svg
+++ b/public/lead-magnets/covers/medicare-starter-guide.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 520" role="img" aria-label="Medicare Starter Guide placeholder cover">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#82A6B1"/>
+      <stop offset="100%" stop-color="#547584"/>
+    </linearGradient>
+    <linearGradient id="spine" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#000" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#000" stop-opacity="0"/>
+    </linearGradient>
+  </defs>
+  <rect width="400" height="520" fill="url(#bg)"/>
+  <rect x="0" y="0" width="18" height="520" fill="url(#spine)"/>
+  <rect x="28" y="28" width="344" height="464" fill="none" stroke="#F5F5F0" stroke-width="1.5" opacity="0.55"/>
+  <text x="200" y="90" fill="#F5F5F0" font-family="Georgia, serif" font-size="18" font-style="italic" text-anchor="middle" letter-spacing="4">SENIORSIMPLE</text>
+  <line x1="130" y1="110" x2="270" y2="110" stroke="#F5F5F0" stroke-width="1" opacity="0.7"/>
+  <text x="200" y="180" fill="#F5F5F0" font-family="Georgia, serif" font-size="22" font-weight="500" text-anchor="middle" opacity="0.9">The plain-English</text>
+  <text x="200" y="235" fill="#F5F5F0" font-family="Georgia, serif" font-size="34" font-weight="700" text-anchor="middle">Medicare</text>
+  <text x="200" y="280" fill="#F5F5F0" font-family="Georgia, serif" font-size="34" font-weight="700" text-anchor="middle">Starter Guide</text>
+  <rect x="120" y="310" width="160" height="1" fill="#F5F5F0"/>
+  <g transform="translate(200 370)" opacity="0.9">
+    <path d="M -40 0 L -20 -20 L 40 -20 L 40 20 L -20 20 Z" fill="none" stroke="#F5F5F0" stroke-width="2"/>
+    <path d="M -20 -20 L -20 20" stroke="#F5F5F0" stroke-width="2"/>
+    <line x1="-10" y1="-10" x2="30" y2="-10" stroke="#F5F5F0" stroke-width="1"/>
+    <line x1="-10" y1="0" x2="30" y2="0" stroke="#F5F5F0" stroke-width="1"/>
+    <line x1="-10" y1="10" x2="20" y2="10" stroke="#F5F5F0" stroke-width="1"/>
+  </g>
+  <text x="200" y="445" fill="#F5F5F0" font-family="Georgia, serif" font-size="13" text-anchor="middle" letter-spacing="1" opacity="0.85">For newly eligible seniors</text>
+</svg>

--- a/src/app/api/deliver-magnet/route.ts
+++ b/src/app/api/deliver-magnet/route.ts
@@ -1,0 +1,198 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { MAGNETS, type MagnetId } from '@/lib/medicare-capture-config'
+
+// SendGrid REST call — no package needed. Fill SENDGRID_API_KEY +
+// SENDGRID_FROM_EMAIL in env to enable. Without them the endpoint no-ops so the
+// capture flow never fails during launch prep (users still get the instant
+// download; GHL sync is already handled by the subscribe trigger).
+const SENDGRID_URL = 'https://api.sendgrid.com/v3/mail/send'
+
+const DEFAULT_FROM_NAME = 'SeniorSimple'
+const DEFAULT_FROM_EMAIL = 'newsletter@seniorsimple.org'
+const SITE_URL = 'https://seniorsimple.org'
+
+interface DeliverBody {
+  email?: string
+  firstName?: string
+  magnetId?: MagnetId
+  pageSlug?: string
+  variant?: string
+  topicTag?: string
+  resultPayload?: unknown
+}
+
+function buildHtml(args: {
+  firstName: string
+  magnetId: MagnetId
+  downloadUrl: string
+  resultPayload?: unknown
+}) {
+  const magnet = MAGNETS[args.magnetId]
+  const greeting = args.firstName ? `Hi ${escapeHtml(args.firstName)},` : 'Hi there,'
+
+  const resultBlock =
+    args.magnetId === 'tool-result' && args.resultPayload
+      ? `<div style="margin:24px 0;padding:16px;background:#F5F5F0;border-radius:8px;font-size:14px;color:#36596A;">
+           <strong>Your inputs / estimate</strong>
+           <pre style="margin:8px 0 0;white-space:pre-wrap;font-family:ui-monospace,Menlo,monospace;font-size:12px;">${escapeHtml(
+             JSON.stringify(args.resultPayload, null, 2),
+           )}</pre>
+         </div>`
+      : ''
+
+  // Placeholder slot for the future compliance-approved offer block — do NOT
+  // insert an agent CTA here without compliance sign-off (CMS/TPMO).
+  const offerSlot = `<!-- offer-slot: reserved, compliance-gated -->`
+
+  return `<!doctype html>
+<html>
+  <body style="margin:0;padding:0;background:#F5F5F0;font-family:Georgia,serif;color:#36596A;">
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:0 auto;padding:32px 24px;">
+      <tr>
+        <td>
+          <h1 style="font-family:Georgia,serif;font-size:28px;margin:0 0 16px;color:#36596A;">
+            ${escapeHtml(magnet.title)}
+          </h1>
+          <p style="font-size:16px;line-height:1.6;margin:0 0 16px;">${greeting}</p>
+          <p style="font-size:16px;line-height:1.6;margin:0 0 24px;">
+            Thanks for requesting the ${escapeHtml(magnet.title)}. You can download it below.
+          </p>
+          <p style="text-align:center;margin:24px 0;">
+            <a href="${args.downloadUrl}"
+               style="display:inline-block;background:#36596A;color:#ffffff;padding:14px 28px;border-radius:8px;text-decoration:none;font-family:Arial,sans-serif;font-size:16px;">
+              Download ${escapeHtml(magnet.title)}
+            </a>
+          </p>
+          ${resultBlock}
+          <p style="font-size:14px;line-height:1.6;margin:32px 0 0;color:#36596A;opacity:.8;">
+            You're receiving this because you requested a guide from SeniorSimple.
+            No agent will contact you.
+          </p>
+          ${offerSlot}
+          <hr style="border:0;border-top:1px solid #E4CDA1;margin:24px 0;">
+          <p style="font-size:12px;line-height:1.5;color:#36596A;opacity:.7;">
+            SeniorSimple · <a href="${SITE_URL}/unsubscribe" style="color:#36596A;">Unsubscribe</a>
+          </p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`
+}
+
+function buildText(args: {
+  firstName: string
+  magnetId: MagnetId
+  downloadUrl: string
+}) {
+  const magnet = MAGNETS[args.magnetId]
+  const greeting = args.firstName ? `Hi ${args.firstName},` : 'Hi there,'
+  return [
+    magnet.title,
+    '',
+    greeting,
+    '',
+    `Thanks for requesting the ${magnet.title}. Download it here:`,
+    args.downloadUrl,
+    '',
+    `You're receiving this because you requested a guide from SeniorSimple. No agent will contact you.`,
+    '',
+    `Unsubscribe: ${SITE_URL}/unsubscribe`,
+  ].join('\n')
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+export async function POST(request: NextRequest) {
+  let body: DeliverBody
+  try {
+    body = (await request.json()) as DeliverBody
+  } catch {
+    return NextResponse.json({ ok: false, error: 'invalid_json' }, { status: 400 })
+  }
+
+  const email = body.email?.trim().toLowerCase() ?? ''
+  const magnetId = body.magnetId
+  if (!email || !EMAIL_RE.test(email)) {
+    return NextResponse.json({ ok: false, error: 'invalid_email' }, { status: 400 })
+  }
+  if (!magnetId || !(magnetId in MAGNETS)) {
+    return NextResponse.json({ ok: false, error: 'invalid_magnet' }, { status: 400 })
+  }
+
+  const magnet = MAGNETS[magnetId]
+  const downloadUrl = `${SITE_URL}${magnet.downloadPath}`
+
+  const apiKey = process.env.SENDGRID_API_KEY
+  const fromEmail = process.env.SENDGRID_FROM_EMAIL || DEFAULT_FROM_EMAIL
+  const fromName = process.env.SENDGRID_FROM_NAME || DEFAULT_FROM_NAME
+
+  // No-op when SendGrid isn't configured. The user already has the instant
+  // download in the success state; GHL sync fires via the subscribe trigger.
+  if (!apiKey) {
+    return NextResponse.json({ ok: true, delivered: false, reason: 'sendgrid_not_configured' })
+  }
+
+  const html = buildHtml({
+    firstName: body.firstName?.trim() ?? '',
+    magnetId,
+    downloadUrl,
+    resultPayload: body.resultPayload,
+  })
+  const text = buildText({
+    firstName: body.firstName?.trim() ?? '',
+    magnetId,
+    downloadUrl,
+  })
+
+  try {
+    const res = await fetch(SENDGRID_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        personalizations: [
+          {
+            to: [{ email }],
+            subject: magnet.emailSubject,
+          },
+        ],
+        from: { email: fromEmail, name: fromName },
+        content: [
+          { type: 'text/plain', value: text },
+          { type: 'text/html', value: html },
+        ],
+        tracking_settings: {
+          click_tracking: { enable: true, enable_text: false },
+          open_tracking: { enable: true },
+        },
+        categories: ['medicare_capture', `magnet:${magnetId}`],
+      }),
+    })
+
+    if (!res.ok) {
+      const errBody = await res.text().catch(() => '')
+      console.error('SendGrid deliver-magnet failed:', res.status, errBody)
+      return NextResponse.json(
+        { ok: false, delivered: false, status: res.status },
+        { status: 502 },
+      )
+    }
+
+    return NextResponse.json({ ok: true, delivered: true })
+  } catch (err) {
+    console.error('deliver-magnet exception:', err)
+    return NextResponse.json({ ok: false, delivered: false }, { status: 500 })
+  }
+}

--- a/src/app/content/[slug]/page.tsx
+++ b/src/app/content/[slug]/page.tsx
@@ -5,6 +5,7 @@ import CalculatorWrapper from '@/components/calculators/CalculatorWrapper';
 import InteractiveTool from '@/components/tools/InteractiveTool';
 import InteractiveChecklist from '@/components/checklists/InteractiveChecklist';
 import ContentSearch from '@/components/search/ContentSearch';
+import MedicareCaptureMount from '@/components/capture/MedicareCaptureMount';
 import { processMarkdownToHTML, extractTableOfContents, calculateReadingTime } from '@/lib/markdown';
 import { Metadata } from 'next';
 
@@ -231,11 +232,17 @@ export default async function ContentPage({ params }: ContentPageProps) {
         notFound();
       }
       return (
-        <InteractiveTool
-          config={content.tool_config}
-          title={content.title}
-          description={content.excerpt}
-        />
+        <>
+          <InteractiveTool
+            config={content.tool_config}
+            title={content.title}
+            description={content.excerpt}
+            postCompletionSlot={
+              <MedicareCaptureMount slug={slug} only={['tool-gate']} />
+            }
+          />
+          <MedicareCaptureMount slug={slug} only={['inline']} />
+        </>
       );
     case 'checklist':
       if (!content.checklist_config) {

--- a/src/app/resources/[slug]/page.tsx
+++ b/src/app/resources/[slug]/page.tsx
@@ -1,0 +1,40 @@
+import { notFound } from 'next/navigation'
+import { Metadata } from 'next'
+import { getAllMagnets, getMagnetByLpSlug } from '@/lib/medicare-capture-config'
+import ResourceLandingPage from '@/components/resources/ResourceLandingPage'
+
+interface ResourcePageProps {
+  params: Promise<{ slug: string }>
+}
+
+export async function generateStaticParams() {
+  return getAllMagnets().map((magnet) => ({ slug: magnet.lpSlug }))
+}
+
+export async function generateMetadata({
+  params,
+}: ResourcePageProps): Promise<Metadata> {
+  const { slug } = await params
+  const magnet = getMagnetByLpSlug(slug)
+  if (!magnet) return {}
+  const canonical = `https://seniorsimple.org/resources/${magnet.lpSlug}`
+  return {
+    title: `${magnet.title} — SeniorSimple`,
+    description: magnet.lpSubhead,
+    openGraph: {
+      title: `${magnet.title} — SeniorSimple`,
+      description: magnet.lpSubhead,
+      url: canonical,
+      type: 'website',
+    },
+    alternates: { canonical },
+    robots: { index: true, follow: true },
+  }
+}
+
+export default async function ResourcePage({ params }: ResourcePageProps) {
+  const { slug } = await params
+  const magnet = getMagnetByLpSlug(slug)
+  if (!magnet) notFound()
+  return <ResourceLandingPage magnet={magnet} />
+}

--- a/src/components/calculators/MedicareCostCalculator.tsx
+++ b/src/components/calculators/MedicareCostCalculator.tsx
@@ -3,6 +3,9 @@
 import React, { useState, useEffect } from 'react';
 import { Calculator, Heart, DollarSign, MapPin, AlertTriangle, CheckCircle, Shield } from 'lucide-react';
 import MedicareLeadForm from './MedicareLeadForm';
+import MedicareCaptureMount from '../capture/MedicareCaptureMount';
+
+const CAPTURE_SLUG = 'medicare-cost-calculator';
 
 interface MedicareResults {
   partAPremium: number;
@@ -390,6 +393,17 @@ export default function MedicareCostCalculator() {
           </div>
         </div>
       )}
+
+      {/* Medicare email-capture: tool-gate appears with results, inline always */}
+      {results && (
+        <MedicareCaptureMount
+          slug={CAPTURE_SLUG}
+          only={['tool-gate']}
+          resultPayload={results}
+        />
+      )}
+
+      <MedicareCaptureMount slug={CAPTURE_SLUG} only={['inline']} />
 
       {/* Lead Generation Form - Appears after results */}
       {results && (

--- a/src/components/capture/ArticleInlineResourceAd.tsx
+++ b/src/components/capture/ArticleInlineResourceAd.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import ResourceAdCard from './ResourceAdCard'
+import { useResolvedMagnet } from './useResolvedMagnet'
+
+export interface ArticleInlineResourceAdProps {
+  slug: string
+  /**
+   * When true, this card only renders on mobile viewports (<lg) — used as the
+   * sidebar's mobile fallback. Set to false when you want it inline on all
+   * widths (e.g. inside a tool-page column).
+   */
+  mobileOnly?: boolean
+}
+
+/**
+ * Horizontal ResourceAdCard mounted inside the article body. Pairs with
+ * <ArticleSidebar> so mobile visitors still see an ad (the sidebar is hidden
+ * on <lg) while desktop visitors only see the sidebar card.
+ */
+export default function ArticleInlineResourceAd({
+  slug,
+  mobileOnly = true,
+}: ArticleInlineResourceAdProps) {
+  const resolved = useResolvedMagnet(slug)
+  if (!resolved) return null
+
+  const wrapperClass = mobileOnly ? 'lg:hidden' : ''
+
+  return (
+    <div className={wrapperClass}>
+      <ResourceAdCard
+        magnetId={resolved.magnetId}
+        pageSlug={slug}
+        topicTag={resolved.topicTag}
+        abArm={resolved.abArm}
+        layout="inline"
+      />
+    </div>
+  )
+}

--- a/src/components/capture/ArticleSidebar.tsx
+++ b/src/components/capture/ArticleSidebar.tsx
@@ -1,0 +1,76 @@
+'use client'
+
+import ResourceAdCard from './ResourceAdCard'
+import { useResolvedMagnet } from './useResolvedMagnet'
+
+export interface ArticleSidebarProps {
+  slug: string
+  className?: string
+}
+
+/**
+ * Right rail rendered alongside `EnhancedArticleDisplay` on desktop.
+ * Slots:
+ *   1. Internal ResourceAdCard — Medicare magnet from slug config, or the
+ *      site-wide default (decision-kit) for non-Medicare articles.
+ *   2. External ad slot (AdSense placeholder — see comment below).
+ *
+ * Hidden on <lg viewports. Pair with `<ArticleInlineResourceAd>` inside the
+ * article body for mobile placement.
+ */
+export default function ArticleSidebar({ slug, className = '' }: ArticleSidebarProps) {
+  const resolved = useResolvedMagnet(slug)
+
+  return (
+    <aside
+      aria-label="Article sidebar"
+      className={`hidden lg:block ${className}`}
+    >
+      <div className="sticky top-8 space-y-6">
+        {resolved && (
+          <ResourceAdCard
+            magnetId={resolved.magnetId}
+            pageSlug={slug}
+            topicTag={resolved.topicTag}
+            abArm={resolved.abArm}
+            layout="sidebar"
+          />
+        )}
+
+        {/*
+          External ad slot — AdSense integration TBD.
+
+          To wire AdSense later:
+            1. Add the loader script once in src/app/layout.tsx:
+               <Script
+                 async
+                 crossOrigin="anonymous"
+                 src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-XXXXXXXXXXXXXXXX"
+                 strategy="afterInteractive"
+               />
+            2. Replace the placeholder <div> below with:
+               <ins
+                 className="adsbygoogle block"
+                 style={{ display: 'block' }}
+                 data-ad-client="ca-pub-XXXXXXXXXXXXXXXX"
+                 data-ad-slot="YYYYYYYYYY"
+                 data-ad-format="auto"
+                 data-full-width-responsive="true"
+               />
+            3. In a useEffect on mount:
+               ;(window as any).adsbygoogle = (window as any).adsbygoogle || []
+               ;(window as any).adsbygoogle.push({})
+        */}
+        <div
+          className="rounded-xl border border-dashed border-[#36596A]/20 bg-[#F5F5F0]/40 p-6 text-center"
+          aria-label="Advertisement slot"
+        >
+          <p className="text-xs uppercase tracking-widest text-[#36596A]/40 mb-2">
+            Advertisement
+          </p>
+          <p className="text-sm text-[#36596A]/60">Ad slot reserved</p>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/src/components/capture/MagnetCaptureForm.tsx
+++ b/src/components/capture/MagnetCaptureForm.tsx
@@ -1,0 +1,347 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { Check, Download, Mail } from 'lucide-react'
+import {
+  MAGNETS,
+  type CaptureVariant,
+  type MagnetId,
+  type TopicTag,
+} from '@/lib/medicare-capture-config'
+import { trackCaptureEvent } from '@/lib/medicare-capture-analytics'
+
+const SUBSCRIBE_ENDPOINT =
+  'https://vpysqshhafthuxvokwqj.supabase.co/functions/v1/subscribe'
+
+export interface MagnetCaptureFormProps {
+  /** Slug of the page hosting this form — used for source_detail + analytics. */
+  pageSlug: string
+  /** Variant that owns this form — informs analytics and source_detail. */
+  variant: CaptureVariant
+  magnetId: MagnetId
+  topicTag: TopicTag
+  resultPayload?: unknown
+  abArm?: string
+  /** Ties into the subscribe `source` field (default: 'capture'). */
+  source?: string
+  /** Visual mode: light background (LPs) or gradient hero (inline units). */
+  theme?: 'light' | 'gradient'
+  /** Optional title/subtitle rendered above the form. */
+  title?: string
+  subtitle?: string
+}
+
+type Status = 'idle' | 'submitting' | 'success' | 'error'
+
+async function submitToSubscribe(args: {
+  email: string
+  firstName: string
+  pageSlug: string
+  variant: CaptureVariant
+  magnetId: MagnetId
+  topicTag: TopicTag
+  honeypot: string
+  source: string
+}) {
+  return fetch(SUBSCRIBE_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: args.email,
+      first_name: args.firstName || null,
+      site_id: 'seniorsimple',
+      source: args.source,
+      source_detail: `${args.pageSlug}|${args.variant}`,
+      tags: [
+        'medicare',
+        args.topicTag,
+        `unit:${args.variant}`,
+        `magnet:${args.magnetId}`,
+      ],
+      website: args.honeypot,
+    }),
+  })
+}
+
+async function triggerMagnetDelivery(args: {
+  email: string
+  firstName: string
+  magnetId: MagnetId
+  pageSlug: string
+  variant: CaptureVariant
+  topicTag: TopicTag
+  resultPayload?: unknown
+}) {
+  try {
+    await fetch('/api/deliver-magnet', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(args),
+      keepalive: true,
+    })
+  } catch {
+    // Delivery failures never block the success flow.
+  }
+}
+
+export default function MagnetCaptureForm({
+  pageSlug,
+  variant,
+  magnetId,
+  topicTag,
+  resultPayload,
+  abArm,
+  source = 'capture',
+  theme = 'gradient',
+  title,
+  subtitle,
+}: MagnetCaptureFormProps) {
+  const magnet = MAGNETS[magnetId]
+  const [email, setEmail] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [honeypot, setHoneypot] = useState('')
+  const [status, setStatus] = useState<Status>('idle')
+  const [message, setMessage] = useState('')
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (status === 'submitting') return
+
+      const trimmed = email.trim().toLowerCase()
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+        setStatus('error')
+        setMessage('Please enter a valid email address.')
+        return
+      }
+
+      setStatus('submitting')
+      setMessage('')
+
+      trackCaptureEvent({
+        eventName: 'capture_submit',
+        pageSlug,
+        variant,
+        magnetId,
+        topicTag,
+        abArm,
+      })
+
+      try {
+        const res = await submitToSubscribe({
+          email: trimmed,
+          firstName: firstName.trim(),
+          pageSlug,
+          variant,
+          magnetId,
+          topicTag,
+          honeypot,
+          source,
+        })
+
+        if (res.status === 429) {
+          setStatus('error')
+          setMessage('One moment — please try again shortly.')
+          return
+        }
+
+        if (!res.ok && res.status !== 200 && res.status !== 201) {
+          const data = await res.json().catch(() => ({}))
+          setStatus('error')
+          setMessage(
+            typeof data?.error === 'string'
+              ? data.error
+              : 'Something went wrong. Please try again.',
+          )
+          return
+        }
+
+        setStatus('success')
+
+        trackCaptureEvent({
+          eventName: 'capture_confirm',
+          pageSlug,
+          variant,
+          magnetId,
+          topicTag,
+          abArm,
+        })
+        void triggerMagnetDelivery({
+          email: trimmed,
+          firstName: firstName.trim(),
+          magnetId,
+          pageSlug,
+          variant,
+          topicTag,
+          resultPayload,
+        })
+      } catch {
+        setStatus('error')
+        setMessage('Network error. Please try again.')
+      }
+    },
+    [
+      status,
+      email,
+      firstName,
+      honeypot,
+      pageSlug,
+      variant,
+      magnetId,
+      topicTag,
+      abArm,
+      resultPayload,
+      source,
+    ],
+  )
+
+  const isLight = theme === 'light'
+  const inputClass = isLight
+    ? 'w-full rounded-lg border-2 border-[#36596A]/20 bg-white px-4 py-3 text-base text-gray-900 placeholder:text-gray-500 focus:border-[#36596A] focus:ring-2 focus:ring-[#36596A]/20 focus:outline-none'
+    : 'w-full rounded-lg border-0 px-4 py-3 text-base text-gray-900 placeholder:text-gray-500 focus:ring-2 focus:ring-[#E4CDA1] focus:outline-none'
+  const labelClass = isLight
+    ? 'block text-sm font-medium text-[#36596A] mb-1'
+    : 'block text-sm font-medium text-white/90 mb-1'
+  const helperClass = isLight
+    ? 'text-xs text-[#36596A]/70 text-center mt-1'
+    : 'text-xs text-white/70 text-center mt-1'
+  const buttonClass = isLight
+    ? 'mt-2 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-[#36596A] px-6 py-4 text-base font-medium text-white hover:bg-[#2a4a5a] transition-colors disabled:opacity-70 disabled:cursor-not-allowed'
+    : 'mt-2 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-white px-6 py-4 text-base font-medium text-[#36596A] hover:bg-[#F5F5F0] transition-colors disabled:opacity-70 disabled:cursor-not-allowed'
+
+  if (status === 'success') {
+    const headingClass = isLight
+      ? 'text-2xl font-serif font-semibold text-[#36596A] mb-3'
+      : 'text-2xl font-serif font-semibold text-white mb-3'
+    const bodyClass = isLight
+      ? 'text-lg text-[#36596A]/85 mb-6'
+      : 'text-lg text-white/90 mb-6'
+    const successBtnClass = isLight
+      ? 'inline-flex items-center gap-2 rounded-lg bg-[#36596A] px-6 py-3 text-base font-medium text-white hover:bg-[#2a4a5a] transition-colors'
+      : 'inline-flex items-center gap-2 rounded-lg bg-white px-6 py-3 text-base font-medium text-[#36596A] hover:bg-[#F5F5F0] transition-colors'
+    const iconBg = isLight ? 'bg-[#E4CDA1]/40' : 'bg-white/20'
+    const iconColor = isLight ? 'text-[#36596A]' : 'text-white'
+
+    return (
+      <div className="text-center">
+        <div
+          className={`mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full ${iconBg}`}
+        >
+          <Check className={`h-6 w-6 ${iconColor}`} aria-hidden />
+        </div>
+        <h3 className={headingClass}>{magnet.successHeadline}</h3>
+        <p className={bodyClass}>{magnet.successBody}</p>
+        <a
+          href={magnet.downloadPath}
+          download={magnet.fileName}
+          className={successBtnClass}
+        >
+          <Download className="h-5 w-5" aria-hidden />
+          Download {magnet.title}
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      {(title || subtitle) && (
+        <div className="mb-6 text-center">
+          {title && (
+            <h3
+              className={`text-2xl font-serif font-semibold mb-2 ${
+                isLight ? 'text-[#36596A]' : 'text-white'
+              }`}
+            >
+              {title}
+            </h3>
+          )}
+          {subtitle && (
+            <p className={isLight ? 'text-[#36596A]/85' : 'text-white/90'}>
+              {subtitle}
+            </p>
+          )}
+        </div>
+      )}
+      <form
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-4 max-w-md mx-auto"
+        noValidate
+      >
+        <label className="block text-left">
+          <span className={labelClass}>First name (optional)</span>
+          <input
+            type="text"
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            autoComplete="given-name"
+            className={inputClass}
+            disabled={status === 'submitting'}
+          />
+        </label>
+
+        <label className="block text-left">
+          <span className={labelClass}>Email address</span>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            required
+            aria-label="Email address"
+            className={inputClass}
+            placeholder="you@example.com"
+            disabled={status === 'submitting'}
+          />
+        </label>
+
+        <button
+          type="submit"
+          disabled={status === 'submitting'}
+          className={buttonClass}
+        >
+          {status === 'submitting' ? (
+            'Sending…'
+          ) : (
+            <>
+              <Mail className="h-5 w-5" aria-hidden />
+              {magnet.ctaLabel}
+            </>
+          )}
+        </button>
+
+        <p className={helperClass}>No obligation, ever. Unsubscribe anytime.</p>
+
+        <input
+          type="text"
+          name="website"
+          value={honeypot}
+          onChange={(e) => setHoneypot(e.target.value)}
+          tabIndex={-1}
+          autoComplete="off"
+          aria-hidden="true"
+          style={{
+            position: 'absolute',
+            left: '-10000px',
+            width: 1,
+            height: 1,
+            opacity: 0,
+          }}
+        />
+
+        {status === 'error' && message && (
+          <p
+            className={
+              isLight
+                ? 'text-sm text-red-700 text-center'
+                : 'text-sm text-white/95 text-center'
+            }
+            role="alert"
+          >
+            {message}
+          </p>
+        )}
+      </form>
+    </div>
+  )
+}

--- a/src/components/capture/MedicareCaptureMount.tsx
+++ b/src/components/capture/MedicareCaptureMount.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import MedicareCaptureUnit from './MedicareCaptureUnit'
+import {
+  getCaptureConfig,
+  resolveCaptureMagnet,
+  type CaptureVariant,
+} from '@/lib/medicare-capture-config'
+
+interface MedicareCaptureMountProps {
+  slug: string
+  /** Which variants from the config to render. Defaults to all non-tool-gate. */
+  only?: CaptureVariant[]
+  /** Optional post-tool result payload for tool-gate variant. */
+  resultPayload?: unknown
+}
+
+/**
+ * Client-only wrapper that resolves the page's capture config + A/B arm, then
+ * renders the configured variants. Safe to drop into any client tree — no-ops
+ * when the slug isn't in the Medicare capture config.
+ */
+export default function MedicareCaptureMount({
+  slug,
+  only,
+  resultPayload,
+}: MedicareCaptureMountProps) {
+  const config = getCaptureConfig(slug)
+  const [resolved, setResolved] = useState<{
+    magnetId: ReturnType<typeof resolveCaptureMagnet>['magnetId']
+    abArm?: string
+  } | null>(null)
+
+  useEffect(() => {
+    if (!config) return
+    setResolved(resolveCaptureMagnet(config))
+  }, [config])
+
+  if (!config || !resolved) return null
+
+  const variantsToRender = (only ?? config.variants).filter((v) =>
+    config.variants.includes(v),
+  )
+
+  return (
+    <>
+      {variantsToRender.map((variant) => (
+        <MedicareCaptureUnit
+          key={variant}
+          pageSlug={config.slug}
+          variant={variant}
+          magnetId={resolved.magnetId}
+          topicTag={config.topicTag}
+          abArm={resolved.abArm}
+          resultPayload={variant === 'tool-gate' ? resultPayload : undefined}
+        />
+      ))}
+    </>
+  )
+}

--- a/src/components/capture/MedicareCaptureUnit.tsx
+++ b/src/components/capture/MedicareCaptureUnit.tsx
@@ -1,0 +1,686 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Mail, Check, X, Download } from 'lucide-react'
+import {
+  MAGNETS,
+  type CaptureVariant,
+  type MagnetId,
+  type TopicTag,
+} from '@/lib/medicare-capture-config'
+import { trackCaptureEvent } from '@/lib/medicare-capture-analytics'
+
+const SUBSCRIBE_ENDPOINT =
+  'https://vpysqshhafthuxvokwqj.supabase.co/functions/v1/subscribe'
+
+export interface MedicareCaptureUnitProps {
+  pageSlug: string
+  variant: CaptureVariant
+  magnetId: MagnetId
+  topicTag: TopicTag
+  resultPayload?: unknown
+  abArm?: string
+  className?: string
+}
+
+type Status = 'idle' | 'submitting' | 'success' | 'error'
+
+interface FormBodyProps extends MedicareCaptureUnitProps {
+  status: Status
+  message: string
+  email: string
+  firstName: string
+  honeypot: string
+  onEmailChange: (v: string) => void
+  onFirstNameChange: (v: string) => void
+  onHoneypotChange: (v: string) => void
+  onSubmit: (e: React.FormEvent) => void
+}
+
+function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = useState(false)
+  useEffect(() => {
+    const check = () => {
+      const touch =
+        window.matchMedia('(pointer: coarse)').matches ||
+        window.matchMedia('(max-width: 767px)').matches
+      setIsMobile(touch)
+    }
+    check()
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
+  return isMobile
+}
+
+function useHasFiredImpression(
+  ref: React.RefObject<HTMLElement | null>,
+  onFire: () => void,
+  enabled: boolean,
+) {
+  const firedRef = useRef(false)
+  useEffect(() => {
+    if (!enabled || firedRef.current) return
+    const el = ref.current
+    if (!el) return
+    if (typeof IntersectionObserver === 'undefined') {
+      firedRef.current = true
+      onFire()
+      return
+    }
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && !firedRef.current) {
+            firedRef.current = true
+            onFire()
+            io.disconnect()
+          }
+        }
+      },
+      { threshold: 0.4 },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [ref, onFire, enabled])
+}
+
+function useExitIntent(onExit: () => void, enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return
+    let fired = false
+    const handler = (e: MouseEvent) => {
+      if (fired) return
+      if (e.clientY <= 0 && e.relatedTarget === null) {
+        fired = true
+        onExit()
+      }
+    }
+    document.addEventListener('mouseout', handler)
+    return () => document.removeEventListener('mouseout', handler)
+  }, [onExit, enabled])
+}
+
+function useScrollTrigger(
+  threshold: number,
+  onCross: () => void,
+  enabled: boolean,
+) {
+  useEffect(() => {
+    if (!enabled) return
+    let fired = false
+    const onScroll = () => {
+      if (fired) return
+      const doc = document.documentElement
+      const scrolled = (window.scrollY + window.innerHeight) / doc.scrollHeight
+      if (scrolled >= threshold) {
+        fired = true
+        onCross()
+      }
+    }
+    window.addEventListener('scroll', onScroll, { passive: true })
+    onScroll()
+    return () => window.removeEventListener('scroll', onScroll)
+  }, [threshold, onCross, enabled])
+}
+
+function FormBody({
+  status,
+  message,
+  email,
+  firstName,
+  honeypot,
+  onEmailChange,
+  onFirstNameChange,
+  onHoneypotChange,
+  onSubmit,
+  variant,
+  magnetId,
+}: FormBodyProps) {
+  const magnet = MAGNETS[magnetId]
+  const isModal = variant === 'exit'
+
+  if (status === 'success') {
+    return (
+      <div className="text-center">
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-white/20">
+          <Check className="h-6 w-6 text-white" aria-hidden />
+        </div>
+        <h3
+          className={`font-serif ${isModal ? 'text-2xl' : 'text-3xl'} font-semibold text-white mb-3`}
+        >
+          {magnet.successHeadline}
+        </h3>
+        <p className="text-lg text-white/90 mb-6">{magnet.successBody}</p>
+        <a
+          href={magnet.downloadPath}
+          download={magnet.fileName}
+          className="inline-flex items-center gap-2 rounded-lg bg-white px-6 py-3 text-base font-medium text-[#36596A] hover:bg-[#F5F5F0] transition-colors"
+        >
+          <Download className="h-5 w-5" aria-hidden />
+          Download {magnet.title}
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="flex flex-col gap-4 max-w-md mx-auto"
+      noValidate
+    >
+      <label className="block text-left">
+        <span className="block text-sm font-medium text-white/90 mb-1">
+          First name (optional)
+        </span>
+        <input
+          type="text"
+          value={firstName}
+          onChange={(e) => onFirstNameChange(e.target.value)}
+          autoComplete="given-name"
+          className="w-full rounded-lg border-0 px-4 py-3 text-base text-gray-900 placeholder:text-gray-500 focus:ring-2 focus:ring-[#E4CDA1] focus:outline-none"
+          disabled={status === 'submitting'}
+        />
+      </label>
+
+      <label className="block text-left">
+        <span className="block text-sm font-medium text-white/90 mb-1">
+          Email address
+        </span>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => onEmailChange(e.target.value)}
+          autoComplete="email"
+          required
+          aria-label="Email address"
+          className="w-full rounded-lg border-0 px-4 py-3 text-base text-gray-900 placeholder:text-gray-500 focus:ring-2 focus:ring-[#E4CDA1] focus:outline-none"
+          placeholder="you@example.com"
+          disabled={status === 'submitting'}
+        />
+      </label>
+
+      <button
+        type="submit"
+        disabled={status === 'submitting'}
+        className="mt-2 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-white px-6 py-4 text-base font-medium text-[#36596A] hover:bg-[#F5F5F0] transition-colors disabled:opacity-70 disabled:cursor-not-allowed"
+      >
+        {status === 'submitting' ? (
+          'Sending…'
+        ) : (
+          <>
+            <Mail className="h-5 w-5" aria-hidden />
+            {magnet.ctaLabel}
+          </>
+        )}
+      </button>
+
+      <p className="text-xs text-white/70 text-center mt-1">
+        No obligation, ever. Unsubscribe anytime.
+      </p>
+
+      <input
+        type="text"
+        name="website"
+        value={honeypot}
+        onChange={(e) => onHoneypotChange(e.target.value)}
+        tabIndex={-1}
+        autoComplete="off"
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          left: '-10000px',
+          width: 1,
+          height: 1,
+          opacity: 0,
+        }}
+      />
+
+      {status === 'error' && message && (
+        <p className="text-sm text-white/95 text-center" role="alert">
+          {message}
+        </p>
+      )}
+    </form>
+  )
+}
+
+async function submitToSubscribe(args: {
+  email: string
+  firstName: string
+  pageSlug: string
+  variant: CaptureVariant
+  magnetId: MagnetId
+  topicTag: TopicTag
+  honeypot: string
+}) {
+  const res = await fetch(SUBSCRIBE_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      email: args.email,
+      first_name: args.firstName || null,
+      site_id: 'seniorsimple',
+      source: 'capture',
+      source_detail: `${args.pageSlug}|${args.variant}`,
+      tags: [
+        'medicare',
+        args.topicTag,
+        `unit:${args.variant}`,
+        `magnet:${args.magnetId}`,
+      ],
+      website: args.honeypot,
+    }),
+  })
+  return res
+}
+
+async function triggerMagnetDelivery(args: {
+  email: string
+  firstName: string
+  magnetId: MagnetId
+  pageSlug: string
+  variant: CaptureVariant
+  topicTag: TopicTag
+  resultPayload?: unknown
+}) {
+  try {
+    await fetch('/api/deliver-magnet', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(args),
+      keepalive: true,
+    })
+  } catch {
+    // Delivery failures don't break the success flow — user still gets the
+    // download link, and subscribe already wrote the row + fired GHL sync.
+  }
+}
+
+function InlinePanel(props: MedicareCaptureUnitProps & { onSubmit: (e: React.FormEvent) => void; status: Status; message: string; email: string; firstName: string; honeypot: string; onEmailChange: (v: string) => void; onFirstNameChange: (v: string) => void; onHoneypotChange: (v: string) => void; hostRef: React.RefObject<HTMLElement | null> }) {
+  const magnet = MAGNETS[props.magnetId]
+  return (
+    <section
+      ref={props.hostRef as React.RefObject<HTMLElement>}
+      className={`my-12 py-12 px-6 rounded-2xl ${props.className ?? ''}`}
+      style={{
+        background: 'linear-gradient(135deg, #36596A 0%, #82A6B1 100%)',
+      }}
+      aria-labelledby={`capture-heading-${props.pageSlug}-${props.variant}`}
+    >
+      <div className="max-w-2xl mx-auto text-center">
+        {props.status !== 'success' && (
+          <>
+            <h2
+              id={`capture-heading-${props.pageSlug}-${props.variant}`}
+              className="text-3xl font-serif font-semibold text-white mb-3"
+            >
+              {props.magnetId === 'tool-result'
+                ? 'Email me my Medicare estimate'
+                : `Free ${magnet.title}`}
+            </h2>
+            <p className="text-lg text-white/90 mb-6">
+              {props.magnetId === 'tool-result'
+                ? 'Get a copy of your estimate plus a plain-English Medicare planning guide. No agent, no sales calls.'
+                : 'A plain-English guide from SeniorSimple. No agent, no sales calls — just the information you asked for.'}
+            </p>
+          </>
+        )}
+        <FormBody {...props} />
+      </div>
+    </section>
+  )
+}
+
+function ExitModal(
+  props: MedicareCaptureUnitProps & {
+    open: boolean
+    onClose: () => void
+    onSubmit: (e: React.FormEvent) => void
+    status: Status
+    message: string
+    email: string
+    firstName: string
+    honeypot: string
+    onEmailChange: (v: string) => void
+    onFirstNameChange: (v: string) => void
+    onHoneypotChange: (v: string) => void
+  },
+) {
+  const dialogRef = useRef<HTMLDivElement | null>(null)
+  const closeRef = useRef<HTMLButtonElement | null>(null)
+
+  useEffect(() => {
+    if (!props.open) return
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    closeRef.current?.focus()
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        props.onClose()
+        return
+      }
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusables = dialogRef.current.querySelectorAll<HTMLElement>(
+          'a[href], button:not([disabled]), input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])',
+        )
+        if (focusables.length === 0) return
+        const first = focusables[0]
+        const last = focusables[focusables.length - 1]
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault()
+          last.focus()
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault()
+          first.focus()
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    const originalOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = originalOverflow
+      previouslyFocused?.focus?.()
+    }
+  }, [props.open, props])
+
+  if (!props.open) return null
+
+  const magnet = MAGNETS[props.magnetId]
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`exit-heading-${props.pageSlug}`}
+      className="fixed inset-0 z-[9999] flex items-center justify-center p-4 bg-black/60"
+      onClick={props.onClose}
+    >
+      <div
+        ref={dialogRef}
+        onClick={(e) => e.stopPropagation()}
+        className="relative w-full max-w-lg rounded-2xl p-8 shadow-2xl"
+        style={{
+          background: 'linear-gradient(135deg, #36596A 0%, #82A6B1 100%)',
+        }}
+      >
+        <button
+          ref={closeRef}
+          type="button"
+          onClick={props.onClose}
+          aria-label="Close"
+          className="absolute top-4 right-4 rounded-full p-2 text-white/80 hover:text-white hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/60"
+        >
+          <X className="h-5 w-5" aria-hidden />
+        </button>
+
+        {props.status !== 'success' && (
+          <div className="text-center mb-6">
+            <h2
+              id={`exit-heading-${props.pageSlug}`}
+              className="text-2xl font-serif font-semibold text-white mb-2"
+            >
+              Before you go — free {magnet.title}
+            </h2>
+            <p className="text-base text-white/90">
+              A plain-English guide from SeniorSimple. No agent, no sales calls.
+            </p>
+          </div>
+        )}
+
+        <FormBody
+          {...props}
+          variant="exit"
+        />
+      </div>
+    </div>
+  )
+}
+
+function MobileStickyBar(props: {
+  onOpen: () => void
+  onDismiss: () => void
+  magnetId: MagnetId
+}) {
+  const magnet = MAGNETS[props.magnetId]
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-[9998] md:hidden">
+      <div
+        className="flex items-center justify-between gap-3 px-4 py-3 shadow-2xl"
+        style={{
+          background: 'linear-gradient(135deg, #36596A 0%, #82A6B1 100%)',
+        }}
+      >
+        <span className="text-sm text-white flex-1">
+          Free {magnet.title} — plain English.
+        </span>
+        <button
+          type="button"
+          onClick={props.onOpen}
+          className="rounded-lg bg-white px-4 py-2 text-sm font-medium text-[#36596A]"
+        >
+          Get it
+        </button>
+        <button
+          type="button"
+          onClick={props.onDismiss}
+          aria-label="Dismiss"
+          className="rounded-full p-1 text-white/80 hover:text-white"
+        >
+          <X className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default function MedicareCaptureUnit(props: MedicareCaptureUnitProps) {
+  const { pageSlug, variant, magnetId, topicTag, resultPayload } = props
+  const isMobile = useIsMobile()
+
+  const abArm = props.abArm
+
+  const [email, setEmail] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [honeypot, setHoneypot] = useState('')
+  const [status, setStatus] = useState<Status>('idle')
+  const [message, setMessage] = useState('')
+  const [modalOpen, setModalOpen] = useState(false)
+  const [mobileBarOpen, setMobileBarOpen] = useState(false)
+  const [mobileBarDismissed, setMobileBarDismissed] = useState(false)
+
+  const hostRef = useRef<HTMLElement | null>(null)
+
+  const fireImpression = useCallback(
+    (v: CaptureVariant) => {
+      trackCaptureEvent({
+        eventName: 'capture_impression',
+        pageSlug,
+        variant: v,
+        magnetId,
+        topicTag,
+        abArm,
+      })
+    },
+    [pageSlug, magnetId, topicTag, abArm],
+  )
+
+  // Impression fires when inline unit scrolls into view.
+  useHasFiredImpression(hostRef, () => fireImpression(variant), variant !== 'exit')
+
+  // Desktop exit intent — only for variant='exit', desktop only.
+  useExitIntent(
+    () => {
+      setModalOpen(true)
+      fireImpression('exit')
+    },
+    variant === 'exit' && !isMobile,
+  )
+
+  // Mobile fallback for variant='exit': show a sticky bar after 60% scroll.
+  useScrollTrigger(
+    0.6,
+    () => {
+      if (mobileBarDismissed) return
+      setMobileBarOpen(true)
+      fireImpression('inline')
+    },
+    variant === 'exit' && isMobile && !mobileBarDismissed,
+  )
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault()
+      if (status === 'submitting') return
+
+      const trimmed = email.trim().toLowerCase()
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+        setStatus('error')
+        setMessage('Please enter a valid email address.')
+        return
+      }
+
+      setStatus('submitting')
+      setMessage('')
+
+      // The variant the user actually interacted with — modal or inline.
+      const activeVariant: CaptureVariant = modalOpen ? 'exit' : variant
+
+      trackCaptureEvent({
+        eventName: 'capture_submit',
+        pageSlug,
+        variant: activeVariant,
+        magnetId,
+        topicTag,
+        abArm,
+      })
+
+      try {
+        const res = await submitToSubscribe({
+          email: trimmed,
+          firstName: firstName.trim(),
+          pageSlug,
+          variant: activeVariant,
+          magnetId,
+          topicTag,
+          honeypot,
+        })
+
+        if (res.status === 429) {
+          setStatus('error')
+          setMessage('One moment — please try again shortly.')
+          return
+        }
+
+        // Any 2xx / 4xx-except-429 (e.g. duplicate) surfaces the same success
+        // state — the prompt calls this out explicitly.
+        if (!res.ok && res.status !== 200 && res.status !== 201) {
+          const data = await res.json().catch(() => ({}))
+          setStatus('error')
+          setMessage(
+            typeof data?.error === 'string'
+              ? data.error
+              : 'Something went wrong. Please try again.',
+          )
+          return
+        }
+
+        setStatus('success')
+
+        // Fire confirm + delivery in parallel.
+        trackCaptureEvent({
+          eventName: 'capture_confirm',
+          pageSlug,
+          variant: activeVariant,
+          magnetId,
+          topicTag,
+          abArm,
+        })
+        void triggerMagnetDelivery({
+          email: trimmed,
+          firstName: firstName.trim(),
+          magnetId,
+          pageSlug,
+          variant: activeVariant,
+          topicTag,
+          resultPayload,
+        })
+      } catch {
+        setStatus('error')
+        setMessage('Network error. Please try again.')
+      }
+    },
+    [
+      status,
+      email,
+      firstName,
+      honeypot,
+      modalOpen,
+      variant,
+      pageSlug,
+      magnetId,
+      topicTag,
+      abArm,
+      resultPayload,
+    ],
+  )
+
+  const formBodyProps = {
+    ...props,
+    status,
+    message,
+    email,
+    firstName,
+    honeypot,
+    onEmailChange: setEmail,
+    onFirstNameChange: setFirstName,
+    onHoneypotChange: setHoneypot,
+    onSubmit: handleSubmit,
+  }
+
+  // Rendering strategy:
+  //  - inline / tool-gate  → always render inline panel
+  //  - exit on desktop     → hidden modal, triggered by exit-intent
+  //  - exit on mobile      → sticky bar + expandable inline modal fallback
+  if (variant === 'inline' || variant === 'tool-gate') {
+    return <InlinePanel {...formBodyProps} hostRef={hostRef} />
+  }
+
+  // variant === 'exit'
+  if (!isMobile) {
+    return (
+      <ExitModal
+        {...formBodyProps}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
+    )
+  }
+
+  // Mobile: sticky bar → expands to inline modal panel when tapped
+  return (
+    <>
+      {mobileBarOpen && !mobileBarDismissed && (
+        <MobileStickyBar
+          magnetId={magnetId}
+          onOpen={() => {
+            setModalOpen(true)
+            fireImpression('inline')
+          }}
+          onDismiss={() => {
+            setMobileBarDismissed(true)
+            setMobileBarOpen(false)
+          }}
+        />
+      )}
+      <ExitModal
+        {...formBodyProps}
+        open={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
+    </>
+  )
+}

--- a/src/components/capture/ResourceAdCard.tsx
+++ b/src/components/capture/ResourceAdCard.tsx
@@ -41,16 +41,20 @@ export default function ResourceAdCard({
   const magnet = MAGNETS[magnetId]
   const rootRef = useRef<HTMLDivElement | null>(null)
 
+  // Map layout → analytics variant so sidebar vs mobile-inline placements are
+  // bucketed separately in the scoreboard.
+  const analyticsVariant = layout === 'sidebar' ? 'sidebar-ad' : 'inline-ad'
+
   const fireImpression = useCallback(() => {
     trackCaptureEvent({
       eventName: 'capture_impression',
       pageSlug,
-      variant: 'inline',
+      variant: analyticsVariant,
       magnetId,
       topicTag,
       abArm,
     })
-  }, [pageSlug, magnetId, topicTag, abArm])
+  }, [pageSlug, magnetId, topicTag, abArm, analyticsVariant])
 
   useEffect(() => {
     if (typeof window === 'undefined') return
@@ -86,12 +90,12 @@ export default function ResourceAdCard({
     trackCaptureEvent({
       eventName: 'capture_submit',
       pageSlug,
-      variant: 'inline',
+      variant: analyticsVariant,
       magnetId,
       topicTag,
       abArm,
     })
-  }, [pageSlug, magnetId, topicTag, abArm])
+  }, [pageSlug, magnetId, topicTag, abArm, analyticsVariant])
 
   if (layout === 'inline') {
     // Horizontal ad card — cover on left, copy + CTA on right.

--- a/src/components/capture/ResourceAdCard.tsx
+++ b/src/components/capture/ResourceAdCard.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+import Link from 'next/link'
+import { ArrowRight } from 'lucide-react'
+import {
+  MAGNETS,
+  type MagnetId,
+  type TopicTag,
+} from '@/lib/medicare-capture-config'
+import { trackCaptureEvent } from '@/lib/medicare-capture-analytics'
+
+export interface ResourceAdCardProps {
+  magnetId: MagnetId
+  /** Slug of the page the card is placed on — for analytics. */
+  pageSlug: string
+  topicTag: TopicTag
+  abArm?: string
+  /** Layout preset. Sidebar = tall/narrow; inline = wide/short. */
+  layout?: 'sidebar' | 'inline'
+  /** Small "AD" label to disclose sponsored slot — hidden on internal cards. */
+  showAdLabel?: boolean
+  className?: string
+}
+
+/**
+ * Ad-styled resource card: cover image + headline + CTA that clicks through to
+ * /resources/[lpSlug]. The LP owns the capture form and magnet delivery, so we
+ * only fire an impression event here — click events fall out naturally when the
+ * user lands on the LP and its form's `capture_impression` fires.
+ */
+export default function ResourceAdCard({
+  magnetId,
+  pageSlug,
+  topicTag,
+  abArm,
+  layout = 'sidebar',
+  showAdLabel = false,
+  className = '',
+}: ResourceAdCardProps) {
+  const magnet = MAGNETS[magnetId]
+  const rootRef = useRef<HTMLDivElement | null>(null)
+
+  const fireImpression = useCallback(() => {
+    trackCaptureEvent({
+      eventName: 'capture_impression',
+      pageSlug,
+      variant: 'inline',
+      magnetId,
+      topicTag,
+      abArm,
+    })
+  }, [pageSlug, magnetId, topicTag, abArm])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const el = rootRef.current
+    if (!el) return
+
+    if (typeof IntersectionObserver === 'undefined') {
+      fireImpression()
+      return
+    }
+
+    let fired = false
+    const io = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && !fired) {
+            fired = true
+            fireImpression()
+            io.disconnect()
+          }
+        }
+      },
+      { threshold: 0.4 },
+    )
+    io.observe(el)
+    return () => io.disconnect()
+  }, [fireImpression])
+
+  const href = `/resources/${magnet.lpSlug}`
+
+  const trackClick = useCallback(() => {
+    // Not a required event per the scoreboard spec, but useful for CTR.
+    trackCaptureEvent({
+      eventName: 'capture_submit',
+      pageSlug,
+      variant: 'inline',
+      magnetId,
+      topicTag,
+      abArm,
+    })
+  }, [pageSlug, magnetId, topicTag, abArm])
+
+  if (layout === 'inline') {
+    // Horizontal ad card — cover on left, copy + CTA on right.
+    return (
+      <div
+        ref={rootRef}
+        className={`my-10 overflow-hidden rounded-2xl bg-[#F5F5F0] shadow-md ring-1 ring-[#36596A]/10 ${className}`}
+      >
+        {showAdLabel && (
+          <div className="px-5 pt-4 text-[10px] font-medium uppercase tracking-widest text-[#36596A]/50">
+            Resource
+          </div>
+        )}
+        <div className="flex flex-col gap-6 p-5 md:flex-row md:items-center md:gap-8 md:p-6">
+          <Link
+            href={href}
+            onClick={trackClick}
+            className="mx-auto block w-32 shrink-0 overflow-hidden rounded-md shadow-lg ring-1 ring-black/10 transition-transform hover:-translate-y-0.5 md:w-40"
+            aria-label={`Get ${magnet.title}`}
+          >
+            <img
+              src={magnet.coverImagePath}
+              alt=""
+              width={400}
+              height={520}
+              className="block h-auto w-full"
+            />
+          </Link>
+          <div className="flex-1 text-center md:text-left">
+            <h3 className="text-2xl font-serif font-semibold text-[#36596A]">
+              {magnet.adHeadline}
+            </h3>
+            <p className="mt-2 text-base text-[#36596A]/80">
+              {magnet.adSubhead}
+            </p>
+            <Link
+              href={href}
+              onClick={trackClick}
+              className="mt-4 inline-flex items-center gap-2 rounded-lg bg-[#36596A] px-6 py-3 text-base font-medium text-white hover:bg-[#2a4a5a] transition-colors"
+            >
+              {magnet.ctaLabel}
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+            <p className="mt-3 text-xs text-[#36596A]/60">
+              No agent, no sales call.
+            </p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Sidebar layout — vertical, compact.
+  return (
+    <div
+      ref={rootRef}
+      className={`overflow-hidden rounded-xl bg-[#F5F5F0] shadow-md ring-1 ring-[#36596A]/10 ${className}`}
+    >
+      {showAdLabel && (
+        <div className="px-4 pt-3 text-[10px] font-medium uppercase tracking-widest text-[#36596A]/50">
+          Resource
+        </div>
+      )}
+      <Link
+        href={href}
+        onClick={trackClick}
+        className="block px-5 pt-5"
+        aria-label={`Get ${magnet.title}`}
+      >
+        <div className="mx-auto w-32 overflow-hidden rounded-md shadow-lg ring-1 ring-black/10 transition-transform hover:-translate-y-0.5">
+          <img
+            src={magnet.coverImagePath}
+            alt=""
+            width={400}
+            height={520}
+            className="block h-auto w-full"
+          />
+        </div>
+      </Link>
+      <div className="p-5 pt-4 text-center">
+        <h3 className="text-lg font-serif font-semibold text-[#36596A]">
+          {magnet.adHeadline}
+        </h3>
+        <p className="mt-2 text-sm text-[#36596A]/80">{magnet.adSubhead}</p>
+        <Link
+          href={href}
+          onClick={trackClick}
+          className="mt-4 inline-flex w-full items-center justify-center gap-2 rounded-lg bg-[#36596A] px-4 py-3 text-sm font-medium text-white hover:bg-[#2a4a5a] transition-colors"
+        >
+          {magnet.ctaLabel}
+          <ArrowRight className="h-4 w-4" aria-hidden />
+        </Link>
+        <p className="mt-2 text-[11px] text-[#36596A]/60">
+          No agent, no sales call.
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/capture/useResolvedMagnet.ts
+++ b/src/components/capture/useResolvedMagnet.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import {
+  DEFAULT_SIDEBAR_MAGNET_ID,
+  DEFAULT_SIDEBAR_TOPIC_TAG,
+  getCaptureConfig,
+  resolveCaptureMagnet,
+  type MagnetId,
+  type TopicTag,
+} from '@/lib/medicare-capture-config'
+
+export interface ResolvedMagnet {
+  magnetId: MagnetId
+  topicTag: TopicTag
+  abArm?: string
+}
+
+/**
+ * Resolve a page slug to the magnet + A/B arm that should be shown in every
+ * ad placement on that page (sidebar + mobile-inline). If the slug isn't in
+ * the Medicare capture config, falls back to the site-wide default magnet.
+ *
+ * Client-only (touches sessionStorage inside resolveCaptureMagnet). Returns
+ * null on the first render, then the resolved value once the effect fires,
+ * so consumers should conditionally render.
+ */
+export function useResolvedMagnet(slug: string): ResolvedMagnet | null {
+  const [resolved, setResolved] = useState<ResolvedMagnet | null>(null)
+
+  useEffect(() => {
+    const config = getCaptureConfig(slug)
+    if (!config) {
+      setResolved({
+        magnetId: DEFAULT_SIDEBAR_MAGNET_ID,
+        topicTag: DEFAULT_SIDEBAR_TOPIC_TAG,
+      })
+      return
+    }
+    const { magnetId, abArm } = resolveCaptureMagnet(config)
+    setResolved({ magnetId, topicTag: config.topicTag, abArm })
+  }, [slug])
+
+  return resolved
+}

--- a/src/components/content/EnhancedArticleDisplay.tsx
+++ b/src/components/content/EnhancedArticleDisplay.tsx
@@ -21,6 +21,7 @@ import { EnhancedArticle } from '../../lib/enhanced-articles'
 import CalculatorWrapper from '../calculators/CalculatorWrapper'
 import InteractiveTool from '../tools/InteractiveTool'
 import InteractiveChecklist from '../checklists/InteractiveChecklist'
+import MedicareCaptureMount from '../capture/MedicareCaptureMount'
 // Markdown processing is now handled on the server side
 
 interface EnhancedArticleDisplayProps {
@@ -497,11 +498,14 @@ export default function EnhancedArticleDisplay({
 
       {/* Article Content */}
       <div className="article-prose prose prose-lg max-w-none">
-        <div 
+        <div
           dangerouslySetInnerHTML={{ __html: article.html_body || article.content }}
           className="text-gray-800 leading-relaxed"
         />
       </div>
+
+      {/* Medicare email-capture unit — no-op unless slug matches config */}
+      <MedicareCaptureMount slug={article.slug} only={['inline', 'exit']} />
 
       {/* Article Footer */}
       <footer className="mt-12 pt-8 border-t border-gray-200">

--- a/src/components/content/EnhancedArticleDisplay.tsx
+++ b/src/components/content/EnhancedArticleDisplay.tsx
@@ -21,7 +21,8 @@ import { EnhancedArticle } from '../../lib/enhanced-articles'
 import CalculatorWrapper from '../calculators/CalculatorWrapper'
 import InteractiveTool from '../tools/InteractiveTool'
 import InteractiveChecklist from '../checklists/InteractiveChecklist'
-import MedicareCaptureMount from '../capture/MedicareCaptureMount'
+import ArticleSidebar from '../capture/ArticleSidebar'
+import ArticleInlineResourceAd from '../capture/ArticleInlineResourceAd'
 // Markdown processing is now handled on the server side
 
 interface EnhancedArticleDisplayProps {
@@ -325,7 +326,10 @@ export default function EnhancedArticleDisplay({
   }
 
   return (
-    <article className={`article-wrapper max-w-4xl mx-auto ${className}`}>
+    <div
+      className={`mx-auto grid max-w-7xl grid-cols-1 gap-8 px-4 sm:px-6 lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-12 ${className}`}
+    >
+    <article className="article-wrapper min-w-0">
       {/* Reading Progress Bar */}
       <div className="article-reading-progress fixed top-0 left-0 w-full h-1 bg-gray-200 z-50">
         <div 
@@ -504,8 +508,8 @@ export default function EnhancedArticleDisplay({
         />
       </div>
 
-      {/* Medicare email-capture unit — no-op unless slug matches config */}
-      <MedicareCaptureMount slug={article.slug} only={['inline', 'exit']} />
+      {/* Mobile-only resource ad — sidebar is hidden on <lg, so surface it here */}
+      <ArticleInlineResourceAd slug={article.slug} />
 
       {/* Article Footer */}
       <footer className="mt-12 pt-8 border-t border-gray-200">
@@ -557,5 +561,8 @@ export default function EnhancedArticleDisplay({
         </div>
       </footer>
     </article>
+
+      <ArticleSidebar slug={article.slug} />
+    </div>
   )
 }

--- a/src/components/resources/ResourceLandingPage.tsx
+++ b/src/components/resources/ResourceLandingPage.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import { useEffect } from 'react'
+import Link from 'next/link'
+import { ArrowLeft, Check } from 'lucide-react'
+import MagnetCaptureForm from '../capture/MagnetCaptureForm'
+import { trackCaptureEvent } from '@/lib/medicare-capture-analytics'
+import type { MagnetSpec } from '@/lib/medicare-capture-config'
+
+interface ResourceLandingPageProps {
+  magnet: MagnetSpec
+}
+
+/**
+ * Landing page for a resource magnet. Fires a capture_impression on mount so
+ * the LP appears in the scoreboard (variant='inline', source_detail carries the
+ * LP slug so it's distinguishable from in-article impressions).
+ */
+export default function ResourceLandingPage({ magnet }: ResourceLandingPageProps) {
+  const pageSlug = `resource:${magnet.lpSlug}`
+
+  useEffect(() => {
+    trackCaptureEvent({
+      eventName: 'capture_impression',
+      pageSlug,
+      variant: 'inline',
+      magnetId: magnet.id,
+      topicTag: 'open-enrollment',
+    })
+    // topicTag on LPs is a placeholder — LPs aren't scoped to a specific
+    // article topic. We could plumb through the referring page's topic later
+    // via querystring if we want per-source LP CTR.
+  }, [magnet.id, magnet.lpSlug, pageSlug])
+
+  return (
+    <div className="min-h-screen bg-white">
+      {/* Slim breadcrumb / back link */}
+      <div className="mx-auto max-w-6xl px-6 pt-6">
+        <Link
+          href="/content"
+          className="inline-flex items-center gap-2 text-sm text-[#36596A]/70 hover:text-[#36596A]"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Back to SeniorSimple
+        </Link>
+      </div>
+
+      {/* Hero */}
+      <section className="mx-auto grid max-w-6xl grid-cols-1 gap-10 px-6 py-12 md:grid-cols-2 md:gap-16 md:py-20">
+        {/* Cover + benefits (left on desktop) */}
+        <div className="order-2 md:order-1">
+          <div className="mx-auto max-w-xs">
+            <div className="overflow-hidden rounded-lg shadow-2xl ring-1 ring-black/10">
+              <img
+                src={magnet.coverImagePath}
+                alt={`${magnet.title} cover`}
+                width={400}
+                height={520}
+                className="block h-auto w-full"
+              />
+            </div>
+          </div>
+
+          <ul className="mx-auto mt-8 max-w-md space-y-3">
+            {magnet.lpBullets.map((bullet) => (
+              <li
+                key={bullet}
+                className="flex items-start gap-3 text-base text-[#36596A]"
+              >
+                <span className="mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[#E4CDA1]/40">
+                  <Check className="h-3.5 w-3.5 text-[#36596A]" aria-hidden />
+                </span>
+                <span>{bullet}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {/* Form (right on desktop) */}
+        <div className="order-1 md:order-2">
+          <div className="mx-auto max-w-md md:sticky md:top-8">
+            <p className="mb-3 text-xs font-medium uppercase tracking-widest text-[#36596A]/60">
+              Free resource
+            </p>
+            <h1 className="text-3xl font-serif font-semibold text-[#36596A] md:text-4xl">
+              {magnet.lpHeadline}
+            </h1>
+            <p className="mt-4 text-lg text-[#36596A]/80">{magnet.lpSubhead}</p>
+
+            <div className="mt-8 rounded-2xl bg-[#F5F5F0] p-6 shadow-md ring-1 ring-[#36596A]/10 md:p-8">
+              <MagnetCaptureForm
+                pageSlug={pageSlug}
+                variant="inline"
+                magnetId={magnet.id}
+                topicTag="open-enrollment"
+                source="lp"
+                theme="light"
+              />
+            </div>
+
+            <p className="mt-4 text-center text-xs text-[#36596A]/60">
+              You&apos;re signing up for the SeniorSimple newsletter. No agent
+              will contact you. Unsubscribe anytime.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Trust footer */}
+      <section className="border-t border-[#36596A]/10 bg-[#F5F5F0]/60">
+        <div className="mx-auto max-w-4xl px-6 py-10 text-center">
+          <p className="text-sm text-[#36596A]/70">
+            SeniorSimple is an independent education resource. We don&apos;t
+            sell insurance. We publish plain-English guides so seniors can make
+            informed decisions.
+          </p>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/tools/InteractiveTool.tsx
+++ b/src/components/tools/InteractiveTool.tsx
@@ -20,6 +20,8 @@ interface InteractiveToolProps {
   title: string
   description?: string
   className?: string
+  /** Rendered inside the completion state (below action buttons). */
+  postCompletionSlot?: React.ReactNode
 }
 
 interface ToolState {
@@ -31,11 +33,12 @@ interface ToolState {
   completionTime: Date | null
 }
 
-export default function InteractiveTool({ 
-  config, 
-  title, 
-  description, 
-  className = '' 
+export default function InteractiveTool({
+  config,
+  title,
+  description,
+  className = '',
+  postCompletionSlot,
 }: InteractiveToolProps) {
   const [state, setState] = useState<ToolState>({
     currentStep: 0,
@@ -359,6 +362,8 @@ export default function InteractiveTool({
             <span>Start Over</span>
           </button>
         </div>
+
+        {postCompletionSlot}
       </div>
     )
   }

--- a/src/lib/medicare-capture-analytics.ts
+++ b/src/lib/medicare-capture-analytics.ts
@@ -1,0 +1,68 @@
+import type { CaptureVariant, MagnetId, TopicTag } from './medicare-capture-config'
+
+export type CaptureEventName =
+  | 'capture_impression'
+  | 'capture_submit'
+  | 'capture_confirm'
+
+const SESSION_KEY = 'ss_session_id'
+
+function getSessionId(): string {
+  if (typeof window === 'undefined') return ''
+  try {
+    let id = window.sessionStorage.getItem(SESSION_KEY)
+    if (!id) {
+      const cryptoRef = (window.crypto as unknown as { randomUUID?: () => string } | undefined)
+      id = cryptoRef?.randomUUID
+        ? cryptoRef.randomUUID()
+        : `sess_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`
+      window.sessionStorage.setItem(SESSION_KEY, id)
+    }
+    return id
+  } catch {
+    return `sess_${Date.now().toString(36)}`
+  }
+}
+
+export interface CaptureEventPayload {
+  eventName: CaptureEventName
+  pageSlug: string
+  variant: CaptureVariant
+  magnetId: MagnetId
+  topicTag: TopicTag
+  abArm?: string
+}
+
+export async function trackCaptureEvent(payload: CaptureEventPayload): Promise<void> {
+  if (typeof window === 'undefined') return
+
+  const session_id = getSessionId()
+  const label = `${payload.pageSlug}|${payload.variant}`
+
+  const body = {
+    event_name: payload.eventName,
+    event_category: 'medicare_capture',
+    event_label: label,
+    session_id,
+    page_url: window.location.href,
+    properties: {
+      site_id: 'seniorsimple',
+      magnetId: payload.magnetId,
+      topicTag: payload.topicTag,
+      variant: payload.variant,
+      pageSlug: payload.pageSlug,
+      ...(payload.abArm ? { ab_arm: payload.abArm } : {}),
+    },
+  }
+
+  try {
+    await fetch('/api/analytics/track-event', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      keepalive: true,
+    })
+  } catch {
+    // Analytics failures never block UX
+  }
+}

--- a/src/lib/medicare-capture-config.ts
+++ b/src/lib/medicare-capture-config.ts
@@ -1,0 +1,160 @@
+export type MagnetId = 'decision-kit' | 'tool-result' | 'starter-guide'
+export type CaptureVariant = 'inline' | 'exit' | 'tool-gate'
+
+export type TopicTag =
+  | 'glp1'
+  | 'medigap'
+  | 'part-d'
+  | 'advantage'
+  | 'medicaid-vs-medicare'
+  | 'open-enrollment'
+  | 'cost-tool'
+
+export interface MagnetSpec {
+  id: MagnetId
+  title: string
+  fileName: string
+  downloadPath: string
+  emailSubject: string
+  successHeadline: string
+  successBody: string
+  ctaLabel: string
+}
+
+export const MAGNETS: Record<MagnetId, MagnetSpec> = {
+  'decision-kit': {
+    id: 'decision-kit',
+    title: '2026 Medicare Decision Kit',
+    fileName: 'seniorsimple-medicare-decision-kit-2026.pdf',
+    downloadPath: '/lead-magnets/medicare-decision-kit-2026.pdf',
+    emailSubject: 'Your 2026 Medicare Decision Kit is inside',
+    successHeadline: 'Your Decision Kit is on the way.',
+    successBody:
+      "Check your inbox — we've sent the 2026 Medicare Decision Kit. You can also download it now.",
+    ctaLabel: 'Send Me the Decision Kit',
+  },
+  'tool-result': {
+    id: 'tool-result',
+    title: 'Your Medicare Estimate',
+    fileName: 'seniorsimple-medicare-estimate.pdf',
+    downloadPath: '/lead-magnets/medicare-estimate-template.pdf',
+    emailSubject: 'Your Medicare estimate is inside',
+    successHeadline: "Your estimate is on the way.",
+    successBody:
+      "We've emailed your Medicare estimate. You can also download a copy now.",
+    ctaLabel: 'Email Me My Estimate',
+  },
+  'starter-guide': {
+    id: 'starter-guide',
+    title: 'Medicare Starter Guide',
+    fileName: 'seniorsimple-medicare-starter-guide.pdf',
+    downloadPath: '/lead-magnets/medicare-starter-guide.pdf',
+    emailSubject: 'Your Medicare Starter Guide is inside',
+    successHeadline: 'Your Starter Guide is on the way.',
+    successBody:
+      "Check your inbox — we've sent the plain-English Medicare Starter Guide. You can also download it now.",
+    ctaLabel: 'Send Me the Starter Guide',
+  },
+}
+
+export interface PageCaptureConfig {
+  slug: string
+  variants: CaptureVariant[]
+  magnetId: MagnetId
+  topicTag: TopicTag
+  abTest?: {
+    armA: MagnetId
+    armB: MagnetId
+  }
+}
+
+const AB_TEST_TOOL: PageCaptureConfig['abTest'] = {
+  armA: 'tool-result',
+  armB: 'decision-kit',
+}
+
+export const MEDICARE_CAPTURE_CONFIG: Record<string, PageCaptureConfig> = {
+  'medicare-cost-calculator': {
+    slug: 'medicare-cost-calculator',
+    variants: ['tool-gate', 'inline'],
+    magnetId: 'tool-result',
+    topicTag: 'cost-tool',
+    abTest: AB_TEST_TOOL,
+  },
+  'medicare-comparison-tool': {
+    slug: 'medicare-comparison-tool',
+    variants: ['tool-gate', 'inline'],
+    magnetId: 'tool-result',
+    topicTag: 'cost-tool',
+    abTest: AB_TEST_TOOL,
+  },
+  'glp1-drugs-covered-by-medicare-2026': {
+    slug: 'glp1-drugs-covered-by-medicare-2026',
+    variants: ['inline', 'exit'],
+    magnetId: 'decision-kit',
+    topicTag: 'glp1',
+  },
+  'best-medicare-supplement-plans-medigap-2026': {
+    slug: 'best-medicare-supplement-plans-medigap-2026',
+    variants: ['inline', 'exit'],
+    magnetId: 'decision-kit',
+    topicTag: 'medigap',
+  },
+  'best-medicare-advantage-plans-2026': {
+    slug: 'best-medicare-advantage-plans-2026',
+    variants: ['inline', 'exit'],
+    magnetId: 'decision-kit',
+    topicTag: 'advantage',
+  },
+  'best-medicare-part-d-drug-plans-2026': {
+    slug: 'best-medicare-part-d-drug-plans-2026',
+    variants: ['inline', 'exit'],
+    magnetId: 'decision-kit',
+    topicTag: 'part-d',
+  },
+  'medicaid-vs-medicare-differences': {
+    slug: 'medicaid-vs-medicare-differences',
+    variants: ['inline', 'exit'],
+    magnetId: 'starter-guide',
+    topicTag: 'medicaid-vs-medicare',
+  },
+  'medicare-open-enrollment-2027-seniors-guide': {
+    slug: 'medicare-open-enrollment-2027-seniors-guide',
+    variants: ['inline', 'exit'],
+    magnetId: 'starter-guide',
+    topicTag: 'open-enrollment',
+  },
+}
+
+export function getCaptureConfig(slug: string): PageCaptureConfig | null {
+  return MEDICARE_CAPTURE_CONFIG[slug] ?? null
+}
+
+/**
+ * Resolve the magnet + A/B arm for a given page config. If the config has no
+ * abTest, returns the default magnetId. If it does, flips a coin the first time
+ * per session and persists the arm in sessionStorage so the same visitor sees a
+ * consistent variant across every capture unit on the page.
+ *
+ * Client-only — safe to call from SSR (returns default), but the arm is only
+ * assigned in the browser.
+ */
+export function resolveCaptureMagnet(config: PageCaptureConfig): {
+  magnetId: MagnetId
+  abArm?: string
+} {
+  if (!config.abTest) return { magnetId: config.magnetId }
+  if (typeof window === 'undefined') return { magnetId: config.magnetId }
+  try {
+    const key = `ss_capture_ab_arm:${config.slug}`
+    let arm = window.sessionStorage.getItem(key)
+    if (arm !== 'A' && arm !== 'B') {
+      arm = Math.random() < 0.5 ? 'A' : 'B'
+      window.sessionStorage.setItem(key, arm)
+    }
+    const magnetId = arm === 'A' ? config.abTest.armA : config.abTest.armB
+    return { magnetId, abArm: arm }
+  } catch {
+    return { magnetId: config.magnetId }
+  }
+}

--- a/src/lib/medicare-capture-config.ts
+++ b/src/lib/medicare-capture-config.ts
@@ -12,49 +12,111 @@ export type TopicTag =
 
 export interface MagnetSpec {
   id: MagnetId
+  /** URL slug for the landing page: /resources/[lpSlug] */
+  lpSlug: string
   title: string
   fileName: string
   downloadPath: string
+  coverImagePath: string
   emailSubject: string
   successHeadline: string
   successBody: string
   ctaLabel: string
+  /** Ad-card copy shown inline in article body / sidebar */
+  adHeadline: string
+  adSubhead: string
+  /** LP hero copy */
+  lpHeadline: string
+  lpSubhead: string
+  lpBullets: string[]
 }
 
 export const MAGNETS: Record<MagnetId, MagnetSpec> = {
   'decision-kit': {
     id: 'decision-kit',
+    lpSlug: 'medicare-decision-kit-2026',
     title: '2026 Medicare Decision Kit',
     fileName: 'seniorsimple-medicare-decision-kit-2026.pdf',
     downloadPath: '/lead-magnets/medicare-decision-kit-2026.pdf',
+    coverImagePath: '/lead-magnets/covers/medicare-decision-kit-2026.svg',
     emailSubject: 'Your 2026 Medicare Decision Kit is inside',
     successHeadline: 'Your Decision Kit is on the way.',
     successBody:
       "Check your inbox — we've sent the 2026 Medicare Decision Kit. You can also download it now.",
     ctaLabel: 'Send Me the Decision Kit',
+    adHeadline: 'Free 2026 Medicare Decision Kit',
+    adSubhead:
+      'Plain-English guide to Medicare, Medigap, Advantage, and Part D — 2026 rates included.',
+    lpHeadline: 'Everything you need to pick a Medicare plan this year.',
+    lpSubhead:
+      "A step-by-step guide from SeniorSimple. No agent will contact you — just the numbers, the trade-offs, and a decision framework you can act on.",
+    lpBullets: [
+      "2026 premiums, deductibles, and out-of-pocket caps for every plan type",
+      "Medigap vs. Medicare Advantage — a plain-English side-by-side",
+      "The one Part D question that saves seniors ~$700/year",
+      "A 3-step enrollment checklist so you don't miss a deadline",
+    ],
   },
   'tool-result': {
     id: 'tool-result',
+    lpSlug: 'medicare-estimate',
     title: 'Your Medicare Estimate',
     fileName: 'seniorsimple-medicare-estimate.pdf',
     downloadPath: '/lead-magnets/medicare-estimate-template.pdf',
+    coverImagePath: '/lead-magnets/covers/medicare-estimate.svg',
     emailSubject: 'Your Medicare estimate is inside',
     successHeadline: "Your estimate is on the way.",
     successBody:
       "We've emailed your Medicare estimate. You can also download a copy now.",
     ctaLabel: 'Email Me My Estimate',
+    adHeadline: 'Get your Medicare estimate — by email',
+    adSubhead:
+      'A saved copy of your Medicare cost estimate, plus the SeniorSimple planning guide.',
+    lpHeadline: 'Your Medicare estimate, on paper.',
+    lpSubhead:
+      "Save your Medicare cost estimate as a PDF and get the SeniorSimple planning guide alongside it. No agent, no sales call.",
+    lpBullets: [
+      "Your monthly premium estimate broken down by Medicare part",
+      "How your income triggers IRMAA — and what to do about it",
+      "The 4-question checklist for picking Medigap vs. Advantage",
+      "Enrollment periods and late-enrollment penalties, explained",
+    ],
   },
   'starter-guide': {
     id: 'starter-guide',
+    lpSlug: 'medicare-starter-guide',
     title: 'Medicare Starter Guide',
     fileName: 'seniorsimple-medicare-starter-guide.pdf',
     downloadPath: '/lead-magnets/medicare-starter-guide.pdf',
+    coverImagePath: '/lead-magnets/covers/medicare-starter-guide.svg',
     emailSubject: 'Your Medicare Starter Guide is inside',
     successHeadline: 'Your Starter Guide is on the way.',
     successBody:
       "Check your inbox — we've sent the plain-English Medicare Starter Guide. You can also download it now.",
     ctaLabel: 'Send Me the Starter Guide',
+    adHeadline: 'New to Medicare? Start here.',
+    adSubhead:
+      'A plain-English Medicare Starter Guide from SeniorSimple. No jargon, no sales calls.',
+    lpHeadline: 'The plain-English Medicare Starter Guide.',
+    lpSubhead:
+      "Everything a newly eligible senior needs to know — in one short, plain-English guide. No jargon, no agents.",
+    lpBullets: [
+      "The four parts of Medicare, in ten minutes",
+      "Enrollment windows and how to avoid a lifetime penalty",
+      "Medicaid vs. Medicare — who qualifies for what",
+      "The 5 questions to ask before picking a plan",
+    ],
   },
+}
+
+export function getMagnetByLpSlug(lpSlug: string): MagnetSpec | null {
+  return (
+    Object.values(MAGNETS).find((m) => m.lpSlug === lpSlug) ?? null
+  )
+}
+
+export function getAllMagnets(): MagnetSpec[] {
+  return Object.values(MAGNETS)
 }
 
 export interface PageCaptureConfig {

--- a/src/lib/medicare-capture-config.ts
+++ b/src/lib/medicare-capture-config.ts
@@ -1,5 +1,14 @@
 export type MagnetId = 'decision-kit' | 'tool-result' | 'starter-guide'
-export type CaptureVariant = 'inline' | 'exit' | 'tool-gate'
+export type CaptureVariant =
+  | 'inline'
+  | 'exit'
+  | 'tool-gate'
+  | 'sidebar-ad'
+  | 'inline-ad'
+
+/** Fallback magnet shown in the sidebar for non-Medicare articles. */
+export const DEFAULT_SIDEBAR_MAGNET_ID: MagnetId = 'decision-kit'
+export const DEFAULT_SIDEBAR_TOPIC_TAG: TopicTag = 'open-enrollment'
 
 export type TopicTag =
   | 'glp1'


### PR DESCRIPTION
## Summary
Ship email-capture units on 8 Medicare pages before AEP, plus a shared resource-LP pattern for the 3 magnets. Two commits, one branch, no cross-cutting refactor yet — the sidebar rework and Simple Life sticky bar (P2 + P3) are separate follow-ups on this branch.

- **8 Medicare pages** get capture units via a slug-based config (`src/lib/medicare-capture-config.ts`). Article pages get `inline` + `exit-intent`; the two tool pages get `tool-gate` + `inline`.
- **3 magnet LPs** at `/resources/[lpSlug]` — cover art + hero + bullets + form. Static-generated from the MAGNETS config; canonical + OG metadata per magnet.
- **`MagnetCaptureForm`** — shared between LPs and the surviving tool-gate variant. Wires to the Publishare `subscribe` edge function (single opt-in, honeypot, dedup + reactivation, 429 handling); GHL sync auto-fires via the existing DB trigger.
- **`/api/deliver-magnet`** — SendGrid REST call, no-ops when `SENDGRID_API_KEY` is unset so the flow never blocks. Compliance-gated placeholder slot for a future offer block; no agent CTA present today.
- **Analytics** — `capture_impression / submit / confirm` events land in `analytics_events` with per-page/variant labels; A/B arm (`tool-result` vs `decision-kit`) recorded on the two tool pages via `resolveCaptureMagnet` + sessionStorage.
- **Placeholder SVG covers** under `public/lead-magnets/covers/` — swap for finished art before launch.

## Test plan
- [ ] `/resources/medicare-decision-kit-2026`, `/resources/medicare-estimate`, `/resources/medicare-starter-guide` all render — cover left, form right (sticky on desktop), bullets underneath cover on mobile
- [ ] Submit an LP form → \`subscribe\` writes a row → GHL contact appears within a minute (DB trigger) → success state shows the instant download button
- [ ] With \`SENDGRID_API_KEY\` set on Vercel, delivery email arrives at the submitted address with subject "Your … is inside"
- [ ] Without \`SENDGRID_API_KEY\`, \`/api/deliver-magnet\` returns \`{ ok: true, delivered: false, reason: 'sendgrid_not_configured' }\` and the download flow still works
- [ ] \`/content/medicare-cost-calculator\` — inline capture unit visible below the form; running the calc surfaces the tool-gate unit with results payload
- [ ] \`/content/medicare-comparison-tool\` — inline capture below the tool; completing the tool surfaces the tool-gate unit
- [ ] Any of the 6 Medicare article slugs (glp1, medigap, advantage, part-d, medicaid-vs-medicare, open-enrollment) — inline unit renders after article body; moving cursor to the browser tab area fires the exit-intent modal on desktop
- [ ] Mobile on an "exit" page — sticky bar appears at 60% scroll instead of the desktop-only exit-intent
- [ ] Honeypot filled → subscribe silently drops (no row written)
- [ ] `capture_impression`, `capture_submit`, `capture_confirm` visible in \`analytics_events\` with the expected \`event_label\` (`<slug>|<variant>`) and \`properties.magnetId\` / \`ab_arm\`

## Known follow-ups (this branch, not this PR)
- **P2**: article template refactor to a sidebar layout — replace inline capture with `ResourceAdCard` in the right rail, drop AdSense placeholder underneath
- **P3**: Simple Life sticky bottom-bar newsletter opt-in
- **P4**: delete inline + exit variants of `MedicareCaptureUnit` once the sidebar owns the ad slot (keep tool-gate)

## Before launch
- Drop the 3 finished magnet PDFs into \`public/lead-magnets/\` (filenames in the README there)
- Drop finished cover art into \`public/lead-magnets/covers/\` (SVG placeholders in place today)
- Set \`SENDGRID_API_KEY\` (+ optionally \`SENDGRID_FROM_EMAIL\`, \`SENDGRID_FROM_NAME\`) on Vercel — preview and prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)